### PR TITLE
add table of consonants

### DIFF
--- a/Phonetics.md
+++ b/Phonetics.md
@@ -19,6 +19,15 @@
 | t | /t/ |	 "t" |
 | f | /f/ | "f" |
 
+|             | Labial | Dental | Alveolar | Postalveolar | Velar | Glottal |
+|-------------|--------|--------|----------|--------------|-------|---------|
+| Nasal       | m      |        | n        |              |       |         |
+| Plosive     | p, b   |        | t, d     |              | k, g  |         |
+| Fricative   | f      | θ      | s        | ʃ            | x     | h       |
+| Approximant | w      |        | l, ɹ     |              | w     |         |
+| Tap         |        |        | ɾ        |              |       |         |
+
+
 # Vowels
 | Symbol | IPA Pronunciation | Anglicized |
 |---------|-------------------|------------|


### PR DESCRIPTION
Consonants are placed in the table according to their place and manner of articulation. It seems there are some unnaturally missing phonemes, but we'll fix that later.