### PR TITLE
fix "yes" not in dictionary

### DIFF
--- a/scripting/index.ts
+++ b/scripting/index.ts
@@ -22,9 +22,10 @@ for (const file of Files) {
 	const content = await readFile(join(SourceDirectory, file), 'utf-8');
 	const rows = content
 		.split('\n')
+		.map(v => v.trim())
 		.filter(
 			v =>
-				!v.includes('Spelling') &&
+				!v.includes('Spelling | Definition') && !v.includes('Word | Meaning') &&
 				v.replaceAll(/[\|\s\-]/g, '').length > 0 &&
 				/^\| [^|]+ \|( [^|]+ \|)+$/.test(v)
 		);


### PR DESCRIPTION
"yes" wasn't in the JSON spec because someone left an extra space at the end of the line. Sounds silly, but the code needed fixing.
Each line is now trimmed before it is matched against the regular expression.
People can now leave whitespace at the start and end of each line with no consequence.