### PR TITLE
Update spec to have headers & subsections in individual parts

### DIFF
--- a/Vocabulary/Pronouns.md
+++ b/Vocabulary/Pronouns.md
@@ -24,11 +24,11 @@
 | boro | any |
 | mire | half |
 
-## Demonstrative Pronouns
+## Demonstrative Pronouns \_
 
 
 <table>
-  
+
   <thead>
     <tr>
       <th rowspan="2"">&nbsp;&nbsp;Use&nbsp;case&nbsp;&nbsp;</th>
@@ -49,7 +49,7 @@
       <th>(english&nbsp;equivalent)</th>
     </tr>
   </thead>
-  
+
   <tbody>
     <tr>
       <td>Prefixes:</td>
@@ -113,3 +113,32 @@
   </tbody>
 
 </table>
+
+The above HTML table is re-arranged in several vanilla Markdown tables for the parser to understand:
+
+## Demonstrative Pronouns (Close To Speaker)
+
+| Word | Meaning | English Equivalent |
+| ---- | ------- | ------------------ |
+| tano | this | this + n. |
+| tani | this | this + adj. |
+| tatu | this way | as such, in this manner |
+| talo | such | such, this kind of |
+
+## Demonstrative Pronouns (Far From Speaker)
+
+| Word | Meaning | English Equivalent |
+| ---- | ------- | ------------------ |
+| kano | that | that + n. |
+| kani | that | that + adj. |
+| katu | that way | as such, in that manner |
+| kal | such | such, that kind of |
+
+## Demonstrative Pronouns (Interrogative Form)
+
+| Word | Meaning | English Equivalent |
+| ---- | ------- | ------------------ |
+| sono | that | what |
+| soni | that | which |
+| sotu | that way | how |
+| solo | such | what kind of |

--- a/rawspec/0-complete.json
+++ b/rawspec/0-complete.json
@@ -1,5 +1,11 @@
 [
 	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
 		"word": "mi",
 		"meaning": "cute",
 		"extra": [],
@@ -104,6 +110,12 @@
 	{
 		"word": "lufi",
 		"meaning": "gaseous",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
 		"extra": [],
 		"type": "adjective"
 	},
@@ -287,6 +299,12 @@
 		"type": "adverb"
 	},
 	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
 		"word": "nen",
 		"meaning": "no",
 		"extra": [],
@@ -322,6 +340,12 @@
 		"type": "adverb"
 	},
 	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
 		"word": "tahi",
 		"meaning": "now",
 		"extra": [],
@@ -345,6 +369,12 @@
 		"type": "adverb"
 	},
 	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
 		"word": "tawa",
 		"meaning": "here",
 		"extra": [],
@@ -363,20 +393,8 @@
 		"type": "adverb"
 	},
 	{
-		"word": "pum",
-		"meaning": "and",
-		"extra": [],
-		"type": "conjunction"
-	},
-	{
-		"word": "ron",
-		"meaning": "or",
-		"extra": [],
-		"type": "conjunction"
-	},
-	{
-		"word": "no",
-		"meaning": "but",
+		"word": "Spelling",
+		"meaning": "Definition",
 		"extra": [],
 		"type": "conjunction"
 	},
@@ -397,6 +415,36 @@
 		"meaning": "but",
 		"extra": [],
 		"type": "conjunction"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "conjunction"
+	},
+	{
+		"word": "pum",
+		"meaning": "and",
+		"extra": [],
+		"type": "conjunction"
+	},
+	{
+		"word": "ron",
+		"meaning": "or",
+		"extra": [],
+		"type": "conjunction"
+	},
+	{
+		"word": "no",
+		"meaning": "but",
+		"extra": [],
+		"type": "conjunction"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "interjection"
 	},
 	{
 		"word": "sim",
@@ -453,6 +501,12 @@
 		"type": "interjection"
 	},
 	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "interjection"
+	},
+	{
 		"word": "sim",
 		"meaning": "yes",
 		"extra": [],
@@ -505,6 +559,12 @@
 		"meaning": "laughter",
 		"extra": [],
 		"type": "interjection"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "noun"
 	},
 	{
 		"word": "kase",
@@ -833,6 +893,12 @@
 	{
 		"word": "dican",
 		"meaning": "defeat",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
 		"extra": [],
 		"type": "noun"
 	},
@@ -2391,50 +2457,8 @@
 		"type": "number"
 	},
 	{
-		"word": "mire-",
-		"meaning": "half, in the middle of",
-		"extra": [],
-		"type": "prefix"
-	},
-	{
-		"word": "gara-",
-		"meaning": "all/every",
-		"extra": [],
-		"type": "prefix"
-	},
-	{
-		"word": "coko-",
-		"meaning": "some",
-		"extra": [],
-		"type": "prefix"
-	},
-	{
-		"word": "boro-",
-		"meaning": "any",
-		"extra": [],
-		"type": "prefix"
-	},
-	{
-		"word": "ni-",
-		"meaning": "negation, other than",
-		"extra": [],
-		"type": "prefix"
-	},
-	{
-		"word": "mo-",
-		"meaning": "inversion, contrary meaning",
-		"extra": [],
-		"type": "prefix"
-	},
-	{
-		"word": "wu-",
-		"meaning": "denotes positive connotation",
-		"extra": [],
-		"type": "prefix"
-	},
-	{
-		"word": "di-",
-		"meaning": "denotes negative connotation",
+		"word": "Spelling",
+		"meaning": "Definition",
 		"extra": [],
 		"type": "prefix"
 	},
@@ -2485,6 +2509,66 @@
 		"meaning": "denotes negative connotation",
 		"extra": [],
 		"type": "prefix"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "mire-",
+		"meaning": "half, in the middle of",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "gara-",
+		"meaning": "all/every",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "coko-",
+		"meaning": "some",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "boro-",
+		"meaning": "any",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "ni-",
+		"meaning": "negation, other than",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "mo-",
+		"meaning": "inversion, contrary meaning",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "wu-",
+		"meaning": "denotes positive connotation",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "di-",
+		"meaning": "denotes negative connotation",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "preposition"
 	},
 	{
 		"word": "ra",
@@ -2555,6 +2639,12 @@
 	{
 		"word": "kaba",
 		"meaning": "far",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
 		"extra": [],
 		"type": "preposition"
 	},
@@ -2731,8 +2821,112 @@
 		"type": "pronoun"
 	},
 	{
+		"word": "tano",
+		"meaning": "this",
+		"extra": [
+			"this + n."
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "tani",
+		"meaning": "this",
+		"extra": [
+			"this + adj."
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "tatu",
+		"meaning": "this way",
+		"extra": [
+			"as such, in this manner"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "talo",
+		"meaning": "such",
+		"extra": [
+			"such, this kind of"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "kano",
+		"meaning": "that",
+		"extra": [
+			"that + n."
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "kani",
+		"meaning": "that",
+		"extra": [
+			"that + adj."
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "katu",
+		"meaning": "that way",
+		"extra": [
+			"as such, in that manner"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "kal",
+		"meaning": "such",
+		"extra": [
+			"such, that kind of"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "sono",
+		"meaning": "that",
+		"extra": [
+			"what"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "soni",
+		"meaning": "that",
+		"extra": [
+			"which"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "sotu",
+		"meaning": "that way",
+		"extra": [
+			"how"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "solo",
+		"meaning": "such",
+		"extra": [
+			"what kind of"
+		],
+		"type": "pronoun"
+	},
+	{
 		"word": " Personal Pronou",
 		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": "Spelling (nonextended — original)",
+		"meaning": "Spelling",
+		"extra": [
+			"Definition"
+		],
 		"type": "pronoun"
 	},
 	{
@@ -2805,6 +2999,12 @@
 		"type": "pronoun"
 	},
 	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
 		"word": "reda",
 		"meaning": "reflexive pronoun, referencing to the thing(s) already mentioned in the sentence",
 		"extra": [],
@@ -2841,9 +3041,152 @@
 		"type": "pronoun"
 	},
 	{
-		"word": " Demonstrative Pronou",
+		"word": " Demonstrative Pronouns ",
 		"extra": [],
 		"type": "pronoun"
+	},
+	{
+		"word": " Demonstrative Pronouns (Close To Speake",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": "Word",
+		"meaning": "Meaning",
+		"extra": [
+			"English Equivalent"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "tano",
+		"meaning": "this",
+		"extra": [
+			"this + n."
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "tani",
+		"meaning": "this",
+		"extra": [
+			"this + adj."
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "tatu",
+		"meaning": "this way",
+		"extra": [
+			"as such, in this manner"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "talo",
+		"meaning": "such",
+		"extra": [
+			"such, this kind of"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": " Demonstrative Pronouns (Far From Speake",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": "Word",
+		"meaning": "Meaning",
+		"extra": [
+			"English Equivalent"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "kano",
+		"meaning": "that",
+		"extra": [
+			"that + n."
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "kani",
+		"meaning": "that",
+		"extra": [
+			"that + adj."
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "katu",
+		"meaning": "that way",
+		"extra": [
+			"as such, in that manner"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "kal",
+		"meaning": "such",
+		"extra": [
+			"such, that kind of"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": " Demonstrative Pronouns (Interrogative For",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": "Word",
+		"meaning": "Meaning",
+		"extra": [
+			"English Equivalent"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "sono",
+		"meaning": "that",
+		"extra": [
+			"what"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "soni",
+		"meaning": "that",
+		"extra": [
+			"which"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "sotu",
+		"meaning": "that way",
+		"extra": [
+			"how"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "solo",
+		"meaning": "such",
+		"extra": [
+			"what kind of"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [
+			"English equivalents"
+		],
+		"type": "suffix"
 	},
 	{
 		"word": "-lu",
@@ -2975,6 +3318,14 @@
 		"type": "suffix"
 	},
 	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [
+			"English equivalents"
+		],
+		"type": "suffix"
+	},
+	{
 		"word": "-ku",
 		"meaning": "establishes verb as uncertain/questioning",
 		"extra": [
@@ -2995,6 +3346,14 @@
 		"meaning": "denotes ability or capacity",
 		"extra": [
 			"-able , -ible , \"capable of\""
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [
+			"English equivalents"
 		],
 		"type": "suffix"
 	},
@@ -3109,6 +3468,14 @@
 		"type": "suffix"
 	},
 	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [
+			"English equivalents"
+		],
+		"type": "suffix"
+	},
+	{
 		"word": "-da",
 		"meaning": "refers to the past tense form of a verb",
 		"extra": [
@@ -3129,6 +3496,14 @@
 		"meaning": "refers to the future tense form of a verb",
 		"extra": [
 			"\"will\", \"shall\""
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [
+			"English equivalents"
 		],
 		"type": "suffix"
 	},
@@ -3154,12 +3529,26 @@
 		"type": "suffix"
 	},
 	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [
+			"English equivalents"
+		],
+		"type": "suffix"
+	},
+	{
 		"word": "-jala",
 		"meaning": "denotes ability or capacity",
 		"extra": [
 			"-able , -ible , \"capable of\""
 		],
 		"type": "suffix"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
+		"extra": [],
+		"type": "verb"
 	},
 	{
 		"word": "mawa",
@@ -3308,6 +3697,12 @@
 	{
 		"word": "cipan",
 		"meaning": "to divide, to split",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "Spelling",
+		"meaning": "Definition",
 		"extra": [],
 		"type": "verb"
 	},

--- a/rawspec/0-complete.json
+++ b/rawspec/0-complete.json
@@ -2,1381 +2,3463 @@
 	{
 		"word": "mi",
 		"meaning": "cute",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "wusita",
 		"meaning": "good",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "disita",
 		"meaning": "bad",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "nen",
 		"meaning": "not",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "toransu",
 		"meaning": "different, other",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "somo",
 		"meaning": "sleepy",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "sekiso",
 		"meaning": "sexy, fuckable",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "deja",
 		"meaning": "active",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "gara",
 		"meaning": "all",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "coko",
 		"meaning": "some",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "boro",
 		"meaning": "any",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "gurati",
 		"meaning": "negative freedom, free (price)",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "lifeta",
 		"meaning": "positive freedom, liberated",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "jala",
 		"meaning": "able, capable of",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "mire",
 		"meaning": "mid, average",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "misu",
 		"meaning": "liquid, fluid",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "ten",
 		"meaning": "solid, rigid",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "lufi",
 		"meaning": "gaseous",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "mi",
+		"meaning": "cute",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "wusita",
+		"meaning": "good",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "disita",
+		"meaning": "bad",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "nen",
+		"meaning": "not",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "toransu",
+		"meaning": "different, other",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "somo",
+		"meaning": "sleepy",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "sekiso",
+		"meaning": "sexy, fuckable",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "deja",
+		"meaning": "active",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "gara",
+		"meaning": "all",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "coko",
+		"meaning": "some",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "boro",
+		"meaning": "any",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "gurati",
+		"meaning": "negative freedom, free (price)",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "lifeta",
+		"meaning": "positive freedom, liberated",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "jala",
+		"meaning": "able, capable of",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "mire",
+		"meaning": "mid, average",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "misu",
+		"meaning": "liquid, fluid",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "ten",
+		"meaning": "solid, rigid",
+		"extra": [],
+		"type": "adjective"
+	},
+	{
+		"word": "lufi",
+		"meaning": "gaseous",
+		"extra": [],
 		"type": "adjective"
 	},
 	{
 		"word": "nen",
 		"meaning": "no",
+		"extra": [],
 		"type": "adverb"
 	},
 	{
 		"word": "con",
 		"meaning": "soon",
+		"extra": [],
 		"type": "adverb"
 	},
 	{
 		"word": "huba",
 		"meaning": "overly",
+		"extra": [],
 		"type": "adverb"
 	},
 	{
 		"word": "sun",
 		"meaning": "why",
+		"extra": [],
 		"type": "adverb"
 	},
 	{
 		"word": "saci",
 		"meaning": "how",
+		"extra": [],
 		"type": "adverb"
 	},
 	{
 		"word": "tahi",
 		"meaning": "now",
+		"extra": [],
 		"type": "adverb"
 	},
 	{
 		"word": "kahi",
 		"meaning": "then",
+		"extra": [],
 		"type": "adverb"
 	},
 	{
 		"word": "sohi",
 		"meaning": "when",
+		"extra": [],
 		"type": "adverb"
 	},
 	{
 		"word": "tawa",
 		"meaning": "here",
+		"extra": [],
 		"type": "adverb"
 	},
 	{
 		"word": "kawa",
 		"meaning": "there",
+		"extra": [],
 		"type": "adverb"
 	},
 	{
 		"word": "sowa",
 		"meaning": "where",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": " Miscellaneous adver",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": "nen",
+		"meaning": "no",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": "con",
+		"meaning": "soon",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": "huba",
+		"meaning": "overly",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": "sun",
+		"meaning": "why",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": "saci",
+		"meaning": "how",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": " Temporal adver",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": "tahi",
+		"meaning": "now",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": "kahi",
+		"meaning": "then",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": "sohi",
+		"meaning": "when",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": " Demonstrative adver",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": "tawa",
+		"meaning": "here",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": "kawa",
+		"meaning": "there",
+		"extra": [],
+		"type": "adverb"
+	},
+	{
+		"word": "sowa",
+		"meaning": "where",
+		"extra": [],
 		"type": "adverb"
 	},
 	{
 		"word": "pum",
 		"meaning": "and",
+		"extra": [],
 		"type": "conjunction"
 	},
 	{
 		"word": "ron",
 		"meaning": "or",
+		"extra": [],
 		"type": "conjunction"
 	},
 	{
 		"word": "no",
 		"meaning": "but",
+		"extra": [],
+		"type": "conjunction"
+	},
+	{
+		"word": "pum",
+		"meaning": "and",
+		"extra": [],
+		"type": "conjunction"
+	},
+	{
+		"word": "ron",
+		"meaning": "or",
+		"extra": [],
+		"type": "conjunction"
+	},
+	{
+		"word": "no",
+		"meaning": "but",
+		"extra": [],
 		"type": "conjunction"
 	},
 	{
 		"word": "sim",
 		"meaning": "yes",
+		"extra": [],
 		"type": "interjection"
 	},
 	{
 		"word": "nen",
 		"meaning": "no",
+		"extra": [],
 		"type": "interjection"
 	},
 	{
 		"word": "henlo",
 		"meaning": "hello",
+		"extra": [],
 		"type": "interjection"
 	},
 	{
 		"word": "na",
 		"meaning": "hi",
+		"extra": [],
 		"type": "interjection"
 	},
 	{
 		"word": "konba",
 		"meaning": "goodbye",
+		"extra": [],
 		"type": "interjection"
 	},
 	{
 		"word": "3",
 		"meaning": "cute!",
+		"extra": [],
 		"type": "interjection"
 	},
 	{
 		"word": "ke",
 		"meaning": "ok",
+		"extra": [],
 		"type": "interjection"
 	},
 	{
 		"word": "biwe",
 		"meaning": "thanks",
+		"extra": [],
 		"type": "interjection"
 	},
 	{
 		"word": "hihi",
 		"meaning": "laughter",
+		"extra": [],
+		"type": "interjection"
+	},
+	{
+		"word": "sim",
+		"meaning": "yes",
+		"extra": [],
+		"type": "interjection"
+	},
+	{
+		"word": "nen",
+		"meaning": "no",
+		"extra": [],
+		"type": "interjection"
+	},
+	{
+		"word": "henlo",
+		"meaning": "hello",
+		"extra": [],
+		"type": "interjection"
+	},
+	{
+		"word": "na",
+		"meaning": "hi",
+		"extra": [],
+		"type": "interjection"
+	},
+	{
+		"word": "konba",
+		"meaning": "goodbye",
+		"extra": [],
+		"type": "interjection"
+	},
+	{
+		"word": "3",
+		"meaning": "cute!",
+		"extra": [],
+		"type": "interjection"
+	},
+	{
+		"word": "ke",
+		"meaning": "ok",
+		"extra": [],
+		"type": "interjection"
+	},
+	{
+		"word": "biwe",
+		"meaning": "thanks",
+		"extra": [],
+		"type": "interjection"
+	},
+	{
+		"word": "hihi",
+		"meaning": "laughter",
+		"extra": [],
 		"type": "interjection"
 	},
 	{
 		"word": "kase",
 		"meaning": "cat",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "hun",
 		"meaning": "dog",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "luma",
 		"meaning": "person",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "mawa",
 		"meaning": "kiss",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "lanmi",
 		"meaning": "food",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "topi",
 		"meaning": "god, deity",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "wantu",
 		"meaning": "number",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "cosi",
 		"meaning": "choice, vote",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "falo",
 		"meaning": "speech, discussion, chat",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "linwa",
 		"meaning": "language",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "keso",
 		"meaning": "cheese",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "sekiso",
 		"meaning": "sex, act of fucking",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "lumaba",
 		"meaning": "friend",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "deja",
 		"meaning": "action",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "gade",
 		"meaning": "guess",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "tempu",
 		"meaning": "time",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "cikondu",
 		"meaning": "second",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "minedu",
 		"meaning": "minute",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "haweru",
 		"meaning": "hour",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "dawu",
 		"meaning": "day",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "natu",
 		"meaning": "night",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "murinu",
 		"meaning": "morning",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "ebeninku",
 		"meaning": "evening",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "monadu",
 		"meaning": "month",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "siconu",
 		"meaning": "season",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "waru",
 		"meaning": "year",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "diwaru",
 		"meaning": "decade",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "huwaru",
 		"meaning": "century",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "newaru",
 		"meaning": "millenium",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "nem",
 		"meaning": "mind",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "pen",
 		"meaning": "movement",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "nepen",
 		"meaning": "feeling",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "gurati",
 		"meaning": "negative freedom",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "lifeta",
 		"meaning": "positive freedom",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "kumi",
 		"meaning": "trans(gender)ness",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "jala",
 		"meaning": "ability",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "mire",
 		"meaning": "half, middle",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "misu",
 		"meaning": "liquid",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "lufi",
 		"meaning": "gas",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "ten",
 		"meaning": "solid",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "kin",
 		"meaning": "thing",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "meta",
 		"meaning": "measurment",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "core",
 		"meaning": "desire",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "jore",
 		"meaning": "need",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "lonki",
 		"meaning": "field of knowledge/study",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "tori",
 		"meaning": "kindness, love",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "toba",
 		"meaning": "word",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "bencun",
 		"meaning": "book",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "gucun",
 		"meaning": "story",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "bengu",
 		"meaning": "storybook",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "cikaran",
 		"meaning": "physical strength",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "cikaranem",
 		"meaning": "mental strength",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "canwa",
 		"meaning": "result",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "wucan",
 		"meaning": "victory",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "dican",
 		"meaning": "defeat",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "kase",
+		"meaning": "cat",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "hun",
+		"meaning": "dog",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "luma",
+		"meaning": "person",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "mawa",
+		"meaning": "kiss",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "lanmi",
+		"meaning": "food",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "topi",
+		"meaning": "god, deity",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "wantu",
+		"meaning": "number",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "cosi",
+		"meaning": "choice, vote",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "falo",
+		"meaning": "speech, discussion, chat",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "linwa",
+		"meaning": "language",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "keso",
+		"meaning": "cheese",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "sekiso",
+		"meaning": "sex, act of fucking",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "lumaba",
+		"meaning": "friend",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "deja",
+		"meaning": "action",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "gade",
+		"meaning": "guess",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "tempu",
+		"meaning": "time",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "cikondu",
+		"meaning": "second",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "minedu",
+		"meaning": "minute",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "haweru",
+		"meaning": "hour",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "dawu",
+		"meaning": "day",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "natu",
+		"meaning": "night",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "murinu",
+		"meaning": "morning",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "ebeninku",
+		"meaning": "evening",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "monadu",
+		"meaning": "month",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "siconu",
+		"meaning": "season",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "waru",
+		"meaning": "year",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "diwaru",
+		"meaning": "decade",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "huwaru",
+		"meaning": "century",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "newaru",
+		"meaning": "millenium",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "nem",
+		"meaning": "mind",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "pen",
+		"meaning": "movement",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "nepen",
+		"meaning": "feeling",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "gurati",
+		"meaning": "negative freedom",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "lifeta",
+		"meaning": "positive freedom",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "kumi",
+		"meaning": "trans(gender)ness",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "jala",
+		"meaning": "ability",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "mire",
+		"meaning": "half, middle",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "misu",
+		"meaning": "liquid",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "lufi",
+		"meaning": "gas",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "ten",
+		"meaning": "solid",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "kin",
+		"meaning": "thing",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "meta",
+		"meaning": "measurment",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "core",
+		"meaning": "desire",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "jore",
+		"meaning": "need",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "lonki",
+		"meaning": "field of knowledge/study",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "tori",
+		"meaning": "kindness, love",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "toba",
+		"meaning": "word",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "bencun",
+		"meaning": "book",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "gucun",
+		"meaning": "story",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "bengu",
+		"meaning": "storybook",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "cikaran",
+		"meaning": "physical strength",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "cikaranem",
+		"meaning": "mental strength",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "canwa",
+		"meaning": "result",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "wucan",
+		"meaning": "victory",
+		"extra": [],
+		"type": "noun"
+	},
+	{
+		"word": "dican",
+		"meaning": "defeat",
+		"extra": [],
 		"type": "noun"
 	},
 	{
 		"word": "Word",
 		"meaning": "Number",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**sero**",
 		"meaning": "0",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**wano**",
 		"meaning": "1",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**duwo**",
 		"meaning": "2",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**tero**",
 		"meaning": "3",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**karo**",
 		"meaning": "4",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**bimo**",
 		"meaning": "5",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**ciko**",
 		"meaning": "6",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**sebo**",
 		"meaning": "7",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**wonto**",
 		"meaning": "8",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**ninto**",
 		"meaning": "9",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**dinko**",
 		"meaning": "10",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dunko",
 		"meaning": "20",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "tenko",
 		"meaning": "30",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "kanko",
 		"meaning": "40",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "binko",
 		"meaning": "50",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "cinko",
 		"meaning": "60",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "senko",
 		"meaning": "70",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "wonko",
 		"meaning": "80",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "ninko",
 		"meaning": "90",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**hundo**",
 		"meaning": "100",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dundo",
 		"meaning": "200",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "tendo",
 		"meaning": "300",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "kando",
 		"meaning": "400",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "bindo",
 		"meaning": "500",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "cindo",
 		"meaning": "600",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "sendo",
 		"meaning": "700",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "wondo",
 		"meaning": "800",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "nindo",
 		"meaning": "900",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**neko**",
 		"meaning": "1000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "duko",
 		"meaning": "2000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "teko",
 		"meaning": "3000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "keko",
 		"meaning": "4000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "biko",
 		"meaning": "5000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "ciko",
 		"meaning": "6000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "seko",
 		"meaning": "7000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "woko",
 		"meaning": "8000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "niko",
 		"meaning": "9000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "diko",
 		"meaning": "10'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dudiko",
 		"meaning": "20'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "tediko",
 		"meaning": "30'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "kadiko",
 		"meaning": "40'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "bidiko",
 		"meaning": "50'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "cidiko",
 		"meaning": "60'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "sediko",
 		"meaning": "70'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "wodiko",
 		"meaning": "80'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "nidiko",
 		"meaning": "90'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "huko",
 		"meaning": "100'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "duhuko",
 		"meaning": "200'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "tehuko",
 		"meaning": "300'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "kahuko",
 		"meaning": "400'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "bihuko",
 		"meaning": "500'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "cihuko",
 		"meaning": "600'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "sehuko",
 		"meaning": "700'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "wohuko",
 		"meaning": "800'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "nihuko",
 		"meaning": "900'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**ranolono**",
 		"meaning": "1'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dunolono",
 		"meaning": "2'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "tenolono",
 		"meaning": "3'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "kenolono",
 		"meaning": "4'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "binolono",
 		"meaning": "5'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "cinolono",
 		"meaning": "6'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "senolono",
 		"meaning": "7'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "wonolono",
 		"meaning": "8'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "ninolono",
 		"meaning": "9'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dinolono",
 		"meaning": "10'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dudinolono",
 		"meaning": "20'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "tedinolono",
 		"meaning": "30'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "kadinolono",
 		"meaning": "40'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "bidinolono",
 		"meaning": "50'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "cidinolono",
 		"meaning": "60'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "sedinolono",
 		"meaning": "70'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "wodinolono",
 		"meaning": "80'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "nidinolono",
 		"meaning": "90'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "hunolono",
 		"meaning": "100'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**rawolono**",
 		"meaning": "1'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "diwolono",
 		"meaning": "10'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "huwolono",
 		"meaning": "100'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**rerolono**",
 		"meaning": "1'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dirolono",
 		"meaning": "10'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "hurolono",
 		"meaning": "100'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**ragolono**",
 		"meaning": "1'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "digolono",
 		"meaning": "10'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "hugolono",
 		"meaning": "100'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**rimolono**",
 		"meaning": "1'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dimolono",
 		"meaning": "10'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "humolono",
 		"meaning": "100'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**rikolono**",
 		"meaning": "1'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dikolono",
 		"meaning": "10'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "hukolono",
 		"meaning": "100'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**rebolono**",
 		"meaning": "1'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dibolono",
 		"meaning": "10'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "hubolono",
 		"meaning": "100'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**rontolono**",
 		"meaning": "1'000'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dintolono",
 		"meaning": "10'000'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "huntolono",
 		"meaning": "100'000'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**rinolono**",
 		"meaning": "1'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dimpolono",
 		"meaning": "10'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "humpolono",
 		"meaning": "100'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "**rinkolono**",
 		"meaning": "1'000'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "dinkolono",
 		"meaning": "100'000'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "hunkolono",
 		"meaning": "100'000'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "Word",
+		"meaning": "Number",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**sero**",
+		"meaning": "0",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**wano**",
+		"meaning": "1",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**duwo**",
+		"meaning": "2",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**tero**",
+		"meaning": "3",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**karo**",
+		"meaning": "4",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**bimo**",
+		"meaning": "5",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**ciko**",
+		"meaning": "6",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**sebo**",
+		"meaning": "7",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**wonto**",
+		"meaning": "8",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**ninto**",
+		"meaning": "9",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**dinko**",
+		"meaning": "10",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dunko",
+		"meaning": "20",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "tenko",
+		"meaning": "30",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "kanko",
+		"meaning": "40",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "binko",
+		"meaning": "50",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "cinko",
+		"meaning": "60",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "senko",
+		"meaning": "70",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "wonko",
+		"meaning": "80",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "ninko",
+		"meaning": "90",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**hundo**",
+		"meaning": "100",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dundo",
+		"meaning": "200",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "tendo",
+		"meaning": "300",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "kando",
+		"meaning": "400",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "bindo",
+		"meaning": "500",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "cindo",
+		"meaning": "600",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "sendo",
+		"meaning": "700",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "wondo",
+		"meaning": "800",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "nindo",
+		"meaning": "900",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**neko**",
+		"meaning": "1000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "duko",
+		"meaning": "2000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "teko",
+		"meaning": "3000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "keko",
+		"meaning": "4000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "biko",
+		"meaning": "5000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "ciko",
+		"meaning": "6000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "seko",
+		"meaning": "7000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "woko",
+		"meaning": "8000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "niko",
+		"meaning": "9000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "diko",
+		"meaning": "10'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dudiko",
+		"meaning": "20'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "tediko",
+		"meaning": "30'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "kadiko",
+		"meaning": "40'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "bidiko",
+		"meaning": "50'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "cidiko",
+		"meaning": "60'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "sediko",
+		"meaning": "70'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "wodiko",
+		"meaning": "80'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "nidiko",
+		"meaning": "90'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "huko",
+		"meaning": "100'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "duhuko",
+		"meaning": "200'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "tehuko",
+		"meaning": "300'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "kahuko",
+		"meaning": "400'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "bihuko",
+		"meaning": "500'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "cihuko",
+		"meaning": "600'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "sehuko",
+		"meaning": "700'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "wohuko",
+		"meaning": "800'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "nihuko",
+		"meaning": "900'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**ranolono**",
+		"meaning": "1'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dunolono",
+		"meaning": "2'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "tenolono",
+		"meaning": "3'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "kenolono",
+		"meaning": "4'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "binolono",
+		"meaning": "5'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "cinolono",
+		"meaning": "6'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "senolono",
+		"meaning": "7'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "wonolono",
+		"meaning": "8'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "ninolono",
+		"meaning": "9'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dinolono",
+		"meaning": "10'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dudinolono",
+		"meaning": "20'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "tedinolono",
+		"meaning": "30'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "kadinolono",
+		"meaning": "40'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "bidinolono",
+		"meaning": "50'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "cidinolono",
+		"meaning": "60'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "sedinolono",
+		"meaning": "70'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "wodinolono",
+		"meaning": "80'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "nidinolono",
+		"meaning": "90'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "hunolono",
+		"meaning": "100'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**rawolono**",
+		"meaning": "1'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "diwolono",
+		"meaning": "10'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "huwolono",
+		"meaning": "100'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**rerolono**",
+		"meaning": "1'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dirolono",
+		"meaning": "10'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "hurolono",
+		"meaning": "100'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**ragolono**",
+		"meaning": "1'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "digolono",
+		"meaning": "10'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "hugolono",
+		"meaning": "100'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**rimolono**",
+		"meaning": "1'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dimolono",
+		"meaning": "10'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "humolono",
+		"meaning": "100'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**rikolono**",
+		"meaning": "1'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dikolono",
+		"meaning": "10'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "hukolono",
+		"meaning": "100'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**rebolono**",
+		"meaning": "1'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dibolono",
+		"meaning": "10'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "hubolono",
+		"meaning": "100'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**rontolono**",
+		"meaning": "1'000'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dintolono",
+		"meaning": "10'000'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "huntolono",
+		"meaning": "100'000'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**rinolono**",
+		"meaning": "1'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dimpolono",
+		"meaning": "10'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "humpolono",
+		"meaning": "100'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "**rinkolono**",
+		"meaning": "1'000'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "dinkolono",
+		"meaning": "100'000'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
+		"type": "number"
+	},
+	{
+		"word": "hunkolono",
+		"meaning": "100'000'000'000'000'000'000'000'000'000'000'000",
+		"extra": [],
 		"type": "number"
 	},
 	{
 		"word": "mire-",
 		"meaning": "half, in the middle of",
+		"extra": [],
 		"type": "prefix"
 	},
 	{
 		"word": "gara-",
 		"meaning": "all/every",
+		"extra": [],
 		"type": "prefix"
 	},
 	{
 		"word": "coko-",
 		"meaning": "some",
+		"extra": [],
 		"type": "prefix"
 	},
 	{
 		"word": "boro-",
 		"meaning": "any",
+		"extra": [],
 		"type": "prefix"
 	},
 	{
 		"word": "ni-",
 		"meaning": "negation, other than",
+		"extra": [],
 		"type": "prefix"
 	},
 	{
 		"word": "mo-",
 		"meaning": "inversion, contrary meaning",
+		"extra": [],
 		"type": "prefix"
 	},
 	{
 		"word": "wu-",
 		"meaning": "denotes positive connotation",
+		"extra": [],
 		"type": "prefix"
 	},
 	{
 		"word": "di-",
 		"meaning": "denotes negative connotation",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "mire-",
+		"meaning": "half, in the middle of",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "gara-",
+		"meaning": "all/every",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "coko-",
+		"meaning": "some",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "boro-",
+		"meaning": "any",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "ni-",
+		"meaning": "negation, other than",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "mo-",
+		"meaning": "inversion, contrary meaning",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "wu-",
+		"meaning": "denotes positive connotation",
+		"extra": [],
+		"type": "prefix"
+	},
+	{
+		"word": "di-",
+		"meaning": "denotes negative connotation",
+		"extra": [],
 		"type": "prefix"
 	},
 	{
 		"word": "ra",
 		"meaning": "in",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "para",
 		"meaning": "for",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "de",
 		"meaning": "of",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "no",
 		"meaning": "but",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "gon",
 		"meaning": "on",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "huba",
 		"meaning": "over",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "wuba",
 		"meaning": "under",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "faba",
 		"meaning": "in front of",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "caba",
 		"meaning": "behind",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "tamba",
 		"meaning": "next to",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "taba",
 		"meaning": "near",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "kaba",
 		"meaning": "far",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "ra",
+		"meaning": "in",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "para",
+		"meaning": "for",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "de",
+		"meaning": "of",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "no",
+		"meaning": "but",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "gon",
+		"meaning": "on",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "huba",
+		"meaning": "over",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "wuba",
+		"meaning": "under",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "faba",
+		"meaning": "in front of",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "caba",
+		"meaning": "behind",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "tamba",
+		"meaning": "next to",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "taba",
+		"meaning": "near",
+		"extra": [],
+		"type": "preposition"
+	},
+	{
+		"word": "kaba",
+		"meaning": "far",
+		"extra": [],
 		"type": "preposition"
 	},
 	{
 		"word": "—",
 		"meaning": "li",
+		"extra": [
+			"animate, unspecified, 1st person"
+		],
 		"type": "pronoun"
 	},
 	{
 		"word": "mid",
 		"meaning": "mida",
+		"extra": [
+			"animate, unspecified, 2nd person"
+		],
 		"type": "pronoun"
 	},
 	{
 		"word": "—",
 		"meaning": "da",
+		"extra": [
+			"animate, unspecified, 3rd person"
+		],
 		"type": "pronoun"
 	},
 	{
 		"word": "—",
 		"meaning": "dase",
+		"extra": [
+			"animate, feminine, 3rd person"
+		],
 		"type": "pronoun"
 	},
 	{
 		"word": "—",
 		"meaning": "dake",
+		"extra": [
+			"animate, androfem, 3rd person"
+		],
 		"type": "pronoun"
 	},
 	{
 		"word": "—",
 		"meaning": "daka",
+		"extra": [
+			"animate, androgynous, 3rd person"
+		],
 		"type": "pronoun"
 	},
 	{
 		"word": "—",
 		"meaning": "daki",
+		"extra": [
+			"animate, andromasc, 3rd person"
+		],
 		"type": "pronoun"
 	},
 	{
 		"word": "—",
 		"meaning": "daci",
+		"extra": [
+			"animate, masculine, 3rd person"
+		],
 		"type": "pronoun"
 	},
 	{
 		"word": "reda",
 		"meaning": "reflexive pronoun, referencing to the thing(s) already mentioned in the sentence",
+		"extra": [],
 		"type": "pronoun"
 	},
 	{
 		"word": "toransu",
 		"meaning": "other",
+		"extra": [],
 		"type": "pronoun"
 	},
 	{
 		"word": "gara",
 		"meaning": "all/every",
+		"extra": [],
 		"type": "pronoun"
 	},
 	{
 		"word": "coko",
 		"meaning": "some",
+		"extra": [],
 		"type": "pronoun"
 	},
 	{
 		"word": "boro",
 		"meaning": "any",
+		"extra": [],
 		"type": "pronoun"
 	},
 	{
 		"word": "mire",
 		"meaning": "half",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": " Personal Pronou",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": "—",
+		"meaning": "li",
+		"extra": [
+			"animate, unspecified, 1st person"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "mid",
+		"meaning": "mida",
+		"extra": [
+			"animate, unspecified, 2nd person"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "—",
+		"meaning": "da",
+		"extra": [
+			"animate, unspecified, 3rd person"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "—",
+		"meaning": "dase",
+		"extra": [
+			"animate, feminine, 3rd person"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "—",
+		"meaning": "dake",
+		"extra": [
+			"animate, androfem, 3rd person"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "—",
+		"meaning": "daka",
+		"extra": [
+			"animate, androgynous, 3rd person"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "—",
+		"meaning": "daki",
+		"extra": [
+			"animate, andromasc, 3rd person"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": "—",
+		"meaning": "daci",
+		"extra": [
+			"animate, masculine, 3rd person"
+		],
+		"type": "pronoun"
+	},
+	{
+		"word": " Indefinite Pronou",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": "reda",
+		"meaning": "reflexive pronoun, referencing to the thing(s) already mentioned in the sentence",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": "toransu",
+		"meaning": "other",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": "gara",
+		"meaning": "all/every",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": "coko",
+		"meaning": "some",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": "boro",
+		"meaning": "any",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": "mire",
+		"meaning": "half",
+		"extra": [],
+		"type": "pronoun"
+	},
+	{
+		"word": " Demonstrative Pronou",
+		"extra": [],
 		"type": "pronoun"
 	},
 	{
 		"word": "-lu",
 		"meaning": "defines an agent noun",
+		"extra": [
+			"-er , -ist"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-sa",
 		"meaning": "indicates plurality",
+		"extra": [
+			"-s, -es"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-ri",
 		"meaning": "establishes a place/event",
+		"extra": [
+			"-ery"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-dufen",
 		"meaning": "refers to an entity or construct that performs a specific action or function",
+		"extra": [
+			"-ifier, -inator"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-fe",
 		"meaning": "connotes opposition",
+		"extra": [
+			"\"against\" , \"in opposition to\"",
+			"—"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-se",
 		"meaning": "establishes feminine characteristics/gender",
+		"extra": [
+			"—"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-ke",
 		"meaning": "establishes androfeminine characteristics/gender",
+		"extra": [
+			"—"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-ka",
 		"meaning": "establishes androgynous characteristics/gender",
+		"extra": [
+			"—"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-ki",
 		"meaning": "establishes andromasc characteristics/gender",
+		"extra": [
+			"—"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-ci",
 		"meaning": "establishes masculine characteristics/gender",
+		"extra": [
+			"—"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-pa",
 		"meaning": "marks word as possessive",
+		"extra": [
+			"-'s"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-lonki",
 		"meaning": "refers to a field of knowledge/study",
+		"extra": [
+			"-ology, -graphy, -nomy, -ics"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-falo",
 		"meaning": "indicates manner or characteristic of speech ",
+		"extra": [
+			"-speak, -talk"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-da",
 		"meaning": "refers to the past tense form of a verb",
+		"extra": [
+			"-ed"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-ne",
 		"meaning": "refers to the present tense form of a verb",
+		"extra": [
+			"-ing"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-lo",
 		"meaning": "refers to the future tense form of a verb",
+		"extra": [
+			"\"will\", \"shall\""
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-ku",
 		"meaning": "establishes verb as uncertain/questioning",
+		"extra": [
+			"—"
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-do",
 		"meaning": "establishes verb as imperative",
+		"extra": [
+			"\"should\", \"ought to\""
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "-jala",
 		"meaning": "denotes ability or capacity",
+		"extra": [
+			"-able , -ible , \"capable of\""
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-lu",
+		"meaning": "defines an agent noun",
+		"extra": [
+			"-er , -ist"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-sa",
+		"meaning": "indicates plurality",
+		"extra": [
+			"-s, -es"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-ri",
+		"meaning": "establishes a place/event",
+		"extra": [
+			"-ery"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-dufen",
+		"meaning": "refers to an entity or construct that performs a specific action or function",
+		"extra": [
+			"-ifier, -inator"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-fe",
+		"meaning": "connotes opposition",
+		"extra": [
+			"\"against\" , \"in opposition to\"",
+			"—"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-se",
+		"meaning": "establishes feminine characteristics/gender",
+		"extra": [
+			"—"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-ke",
+		"meaning": "establishes androfeminine characteristics/gender",
+		"extra": [
+			"—"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-ka",
+		"meaning": "establishes androgynous characteristics/gender",
+		"extra": [
+			"—"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-ki",
+		"meaning": "establishes andromasc characteristics/gender",
+		"extra": [
+			"—"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-ci",
+		"meaning": "establishes masculine characteristics/gender",
+		"extra": [
+			"—"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-pa",
+		"meaning": "marks word as possessive",
+		"extra": [
+			"-'s"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-lonki",
+		"meaning": "refers to a field of knowledge/study",
+		"extra": [
+			"-ology, -graphy, -nomy, -ics"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-falo",
+		"meaning": "indicates manner or characteristic of speech ",
+		"extra": [
+			"-speak, -talk"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": " Verb suffix",
+		"extra": [],
+		"type": "suffix"
+	},
+	{
+		"word": "-da",
+		"meaning": "refers to the past tense form of a verb",
+		"extra": [
+			"-ed"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-ne",
+		"meaning": "refers to the present tense form of a verb",
+		"extra": [
+			"-ing"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-lo",
+		"meaning": "refers to the future tense form of a verb",
+		"extra": [
+			"\"will\", \"shall\""
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-ku",
+		"meaning": "establishes verb as uncertain/questioning",
+		"extra": [
+			"—"
+		],
+		"type": "suffix"
+	},
+	{
+		"word": "-do",
+		"meaning": "establishes verb as imperative",
+		"extra": [
+			"\"should\", \"ought to\""
+		],
+		"type": "suffix"
+	},
+	{
+		"word": " Adjective suffix",
+		"extra": [],
+		"type": "suffix"
+	},
+	{
+		"word": "-jala",
+		"meaning": "denotes ability or capacity",
+		"extra": [
+			"-able , -ible , \"capable of\""
+		],
 		"type": "suffix"
 	},
 	{
 		"word": "mawa",
 		"meaning": "kiss",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "binta",
 		"meaning": "eat",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "sanu",
 		"meaning": "be",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "tenco",
 		"meaning": "have",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "somo",
 		"meaning": "sleep",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "cosi",
 		"meaning": "choose, vote",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "falo",
 		"meaning": "speak, say, tell",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "toransu",
 		"meaning": "differ",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "mahen",
 		"meaning": "make, create",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "sekiso",
 		"meaning": "have sex, fuck",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "deja",
 		"meaning": "do, act",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "gade",
 		"meaning": "guess",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "nem",
 		"meaning": "think",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "pen",
 		"meaning": "move",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "nepen",
 		"meaning": "feel",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "gurati",
 		"meaning": "induce negative freedom, reduce cost to none",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "lifeta",
 		"meaning": "induce positive freedom",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "jala",
 		"meaning": "can, be able to",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "meta",
 		"meaning": "measure",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "core",
 		"meaning": "want",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "jore",
 		"meaning": "need",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "pora",
 		"meaning": "to add, to increase",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "mina",
 		"meaning": "to subtract, to decrease, to remove",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "mulipa",
 		"meaning": "to multiply",
+		"extra": [],
 		"type": "verb"
 	},
 	{
 		"word": "cipan",
 		"meaning": "to divide, to split",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "mawa",
+		"meaning": "kiss",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "binta",
+		"meaning": "eat",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "sanu",
+		"meaning": "be",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "tenco",
+		"meaning": "have",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "somo",
+		"meaning": "sleep",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "cosi",
+		"meaning": "choose, vote",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "falo",
+		"meaning": "speak, say, tell",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "toransu",
+		"meaning": "differ",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "mahen",
+		"meaning": "make, create",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "sekiso",
+		"meaning": "have sex, fuck",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "deja",
+		"meaning": "do, act",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "gade",
+		"meaning": "guess",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "nem",
+		"meaning": "think",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "pen",
+		"meaning": "move",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "nepen",
+		"meaning": "feel",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "gurati",
+		"meaning": "induce negative freedom, reduce cost to none",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "lifeta",
+		"meaning": "induce positive freedom",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "jala",
+		"meaning": "can, be able to",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "meta",
+		"meaning": "measure",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "core",
+		"meaning": "want",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "jore",
+		"meaning": "need",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "pora",
+		"meaning": "to add, to increase",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "mina",
+		"meaning": "to subtract, to decrease, to remove",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "mulipa",
+		"meaning": "to multiply",
+		"extra": [],
+		"type": "verb"
+	},
+	{
+		"word": "cipan",
+		"meaning": "to divide, to split",
+		"extra": [],
 		"type": "verb"
 	}
 ]

--- a/rawspec/adjectives.json
+++ b/rawspec/adjectives.json
@@ -1,7 +1,17 @@
 [
 	{
 		"type": "adjective",
+		"title": null,
+		"headers": [
+			"Word",
+			"Meaning"
+		],
 		"entries": [
+			{
+				"word": "Spelling",
+				"meaning": "Definition",
+				"extra": []
+			},
 			{
 				"word": "mi",
 				"meaning": "cute",

--- a/rawspec/adjectives.json
+++ b/rawspec/adjectives.json
@@ -1,74 +1,97 @@
 [
 	{
-		"word": "mi",
-		"meaning": "cute"
-	},
-	{
-		"word": "wusita",
-		"meaning": "good"
-	},
-	{
-		"word": "disita",
-		"meaning": "bad"
-	},
-	{
-		"word": "nen",
-		"meaning": "not"
-	},
-	{
-		"word": "toransu",
-		"meaning": "different, other"
-	},
-	{
-		"word": "somo",
-		"meaning": "sleepy"
-	},
-	{
-		"word": "sekiso",
-		"meaning": "sexy, fuckable"
-	},
-	{
-		"word": "deja",
-		"meaning": "active"
-	},
-	{
-		"word": "gara",
-		"meaning": "all"
-	},
-	{
-		"word": "coko",
-		"meaning": "some"
-	},
-	{
-		"word": "boro",
-		"meaning": "any"
-	},
-	{
-		"word": "gurati",
-		"meaning": "negative freedom, free (price)"
-	},
-	{
-		"word": "lifeta",
-		"meaning": "positive freedom, liberated"
-	},
-	{
-		"word": "jala",
-		"meaning": "able, capable of"
-	},
-	{
-		"word": "mire",
-		"meaning": "mid, average"
-	},
-	{
-		"word": "misu",
-		"meaning": "liquid, fluid"
-	},
-	{
-		"word": "ten",
-		"meaning": "solid, rigid"
-	},
-	{
-		"word": "lufi",
-		"meaning": "gaseous"
+		"type": "adjective",
+		"entries": [
+			{
+				"word": "mi",
+				"meaning": "cute",
+				"extra": []
+			},
+			{
+				"word": "wusita",
+				"meaning": "good",
+				"extra": []
+			},
+			{
+				"word": "disita",
+				"meaning": "bad",
+				"extra": []
+			},
+			{
+				"word": "nen",
+				"meaning": "not",
+				"extra": []
+			},
+			{
+				"word": "toransu",
+				"meaning": "different, other",
+				"extra": []
+			},
+			{
+				"word": "somo",
+				"meaning": "sleepy",
+				"extra": []
+			},
+			{
+				"word": "sekiso",
+				"meaning": "sexy, fuckable",
+				"extra": []
+			},
+			{
+				"word": "deja",
+				"meaning": "active",
+				"extra": []
+			},
+			{
+				"word": "gara",
+				"meaning": "all",
+				"extra": []
+			},
+			{
+				"word": "coko",
+				"meaning": "some",
+				"extra": []
+			},
+			{
+				"word": "boro",
+				"meaning": "any",
+				"extra": []
+			},
+			{
+				"word": "gurati",
+				"meaning": "negative freedom, free (price)",
+				"extra": []
+			},
+			{
+				"word": "lifeta",
+				"meaning": "positive freedom, liberated",
+				"extra": []
+			},
+			{
+				"word": "jala",
+				"meaning": "able, capable of",
+				"extra": []
+			},
+			{
+				"word": "mire",
+				"meaning": "mid, average",
+				"extra": []
+			},
+			{
+				"word": "misu",
+				"meaning": "liquid, fluid",
+				"extra": []
+			},
+			{
+				"word": "ten",
+				"meaning": "solid, rigid",
+				"extra": []
+			},
+			{
+				"word": "lufi",
+				"meaning": "gaseous",
+				"extra": []
+			}
+		]
 	}
 ]

--- a/rawspec/adverbs.json
+++ b/rawspec/adverbs.json
@@ -1,46 +1,75 @@
 [
 	{
-		"word": "nen",
-		"meaning": "no"
+		"type": "adverb",
+		"title": "Temporal adverbs",
+		"entries": [
+			{
+				"word": "nen",
+				"meaning": "no",
+				"extra": []
+			},
+			{
+				"word": "con",
+				"meaning": "soon",
+				"extra": []
+			},
+			{
+				"word": "huba",
+				"meaning": "overly",
+				"extra": []
+			},
+			{
+				"word": "sun",
+				"meaning": "why",
+				"extra": []
+			},
+			{
+				"word": "saci",
+				"meaning": "how",
+				"extra": []
+			}
+		]
 	},
 	{
-		"word": "con",
-		"meaning": "soon"
+		"type": "adverb",
+		"title": "Demonstrative adverbs",
+		"entries": [
+			{
+				"word": "tahi",
+				"meaning": "now",
+				"extra": []
+			},
+			{
+				"word": "kahi",
+				"meaning": "then",
+				"extra": []
+			},
+			{
+				"word": "sohi",
+				"meaning": "when",
+				"extra": []
+			}
+		]
 	},
 	{
-		"word": "huba",
-		"meaning": "overly"
-	},
-	{
-		"word": "sun",
-		"meaning": "why"
-	},
-	{
-		"word": "saci",
-		"meaning": "how"
-	},
-	{
-		"word": "tahi",
-		"meaning": "now"
-	},
-	{
-		"word": "kahi",
-		"meaning": "then"
-	},
-	{
-		"word": "sohi",
-		"meaning": "when"
-	},
-	{
-		"word": "tawa",
-		"meaning": "here"
-	},
-	{
-		"word": "kawa",
-		"meaning": "there"
-	},
-	{
-		"word": "sowa",
-		"meaning": "where"
+		"type": "adverb",
+		"title": "Demonstrative adverbs",
+		"entries": [
+			{
+				"word": "tawa",
+				"meaning": "here",
+				"extra": []
+			},
+			{
+				"word": "kawa",
+				"meaning": "there",
+				"extra": []
+			},
+			{
+				"word": "sowa",
+				"meaning": "where",
+				"extra": []
+			}
+		]
 	}
 ]

--- a/rawspec/adverbs.json
+++ b/rawspec/adverbs.json
@@ -28,6 +28,10 @@
 				"meaning": "how",
 				"extra": []
 			}
+		],
+		"headers": [
+			"Spelling",
+			"Definition"
 		]
 	},
 	{
@@ -49,11 +53,19 @@
 				"meaning": "when",
 				"extra": []
 			}
+		],
+		"headers": [
+			"Spelling",
+			"Definition"
 		]
 	},
 	{
 		"type": "adverb",
 		"title": "Demonstrative adverbs",
+		"headers": [
+			"Spelling",
+			"Definition"
+		],
 		"entries": [
 			{
 				"word": "tawa",

--- a/rawspec/conjunctions.json
+++ b/rawspec/conjunctions.json
@@ -1,7 +1,17 @@
 [
 	{
 		"type": "conjunction",
+		"title": null,
+		"headers": [
+			"Word",
+			"Meaning"
+		],
 		"entries": [
+			{
+				"word": "Spelling",
+				"meaning": "Definition",
+				"extra": []
+			},
 			{
 				"word": "pum",
 				"meaning": "and",

--- a/rawspec/conjunctions.json
+++ b/rawspec/conjunctions.json
@@ -1,14 +1,22 @@
 [
 	{
-		"word": "pum",
-		"meaning": "and"
-	},
-	{
-		"word": "ron",
-		"meaning": "or"
-	},
-	{
-		"word": "no",
-		"meaning": "but"
+		"type": "conjunction",
+		"entries": [
+			{
+				"word": "pum",
+				"meaning": "and",
+				"extra": []
+			},
+			{
+				"word": "ron",
+				"meaning": "or",
+				"extra": []
+			},
+			{
+				"word": "no",
+				"meaning": "but",
+				"extra": []
+			}
+		]
 	}
 ]

--- a/rawspec/interjections.json
+++ b/rawspec/interjections.json
@@ -1,7 +1,17 @@
 [
 	{
 		"type": "interjection",
+		"title": null,
+		"headers": [
+			"Word",
+			"Meaning"
+		],
 		"entries": [
+			{
+				"word": "Spelling",
+				"meaning": "Definition",
+				"extra": []
+			},
 			{
 				"word": "sim",
 				"meaning": "yes",

--- a/rawspec/interjections.json
+++ b/rawspec/interjections.json
@@ -1,38 +1,52 @@
 [
 	{
-		"word": "sim",
-		"meaning": "yes"
-	},
-	{
-		"word": "nen",
-		"meaning": "no"
-	},
-	{
-		"word": "henlo",
-		"meaning": "hello"
-	},
-	{
-		"word": "na",
-		"meaning": "hi"
-	},
-	{
-		"word": "konba",
-		"meaning": "goodbye"
-	},
-	{
-		"word": "3",
-		"meaning": "cute!"
-	},
-	{
-		"word": "ke",
-		"meaning": "ok"
-	},
-	{
-		"word": "biwe",
-		"meaning": "thanks"
-	},
-	{
-		"word": "hihi",
-		"meaning": "laughter"
+		"type": "interjection",
+		"entries": [
+			{
+				"word": "sim",
+				"meaning": "yes",
+				"extra": []
+			},
+			{
+				"word": "nen",
+				"meaning": "no",
+				"extra": []
+			},
+			{
+				"word": "henlo",
+				"meaning": "hello",
+				"extra": []
+			},
+			{
+				"word": "na",
+				"meaning": "hi",
+				"extra": []
+			},
+			{
+				"word": "konba",
+				"meaning": "goodbye",
+				"extra": []
+			},
+			{
+				"word": "3",
+				"meaning": "cute!",
+				"extra": []
+			},
+			{
+				"word": "ke",
+				"meaning": "ok",
+				"extra": []
+			},
+			{
+				"word": "biwe",
+				"meaning": "thanks",
+				"extra": []
+			},
+			{
+				"word": "hihi",
+				"meaning": "laughter",
+				"extra": []
+			}
+		]
 	}
 ]

--- a/rawspec/nouns.json
+++ b/rawspec/nouns.json
@@ -1,7 +1,17 @@
 [
 	{
 		"type": "noun",
+		"title": null,
+		"headers": [
+			"Word",
+			"Meaning"
+		],
 		"entries": [
+			{
+				"word": "Spelling",
+				"meaning": "Definition",
+				"extra": []
+			},
 			{
 				"word": "kase",
 				"meaning": "cat",

--- a/rawspec/nouns.json
+++ b/rawspec/nouns.json
@@ -1,222 +1,282 @@
 [
 	{
-		"word": "kase",
-		"meaning": "cat"
-	},
-	{
-		"word": "hun",
-		"meaning": "dog"
-	},
-	{
-		"word": "luma",
-		"meaning": "person"
-	},
-	{
-		"word": "mawa",
-		"meaning": "kiss"
-	},
-	{
-		"word": "lanmi",
-		"meaning": "food"
-	},
-	{
-		"word": "topi",
-		"meaning": "god, deity"
-	},
-	{
-		"word": "wantu",
-		"meaning": "number"
-	},
-	{
-		"word": "cosi",
-		"meaning": "choice, vote"
-	},
-	{
-		"word": "falo",
-		"meaning": "speech, discussion, chat"
-	},
-	{
-		"word": "linwa",
-		"meaning": "language"
-	},
-	{
-		"word": "keso",
-		"meaning": "cheese"
-	},
-	{
-		"word": "sekiso",
-		"meaning": "sex, act of fucking"
-	},
-	{
-		"word": "lumaba",
-		"meaning": "friend"
-	},
-	{
-		"word": "deja",
-		"meaning": "action"
-	},
-	{
-		"word": "gade",
-		"meaning": "guess"
-	},
-	{
-		"word": "tempu",
-		"meaning": "time"
-	},
-	{
-		"word": "cikondu",
-		"meaning": "second"
-	},
-	{
-		"word": "minedu",
-		"meaning": "minute"
-	},
-	{
-		"word": "haweru",
-		"meaning": "hour"
-	},
-	{
-		"word": "dawu",
-		"meaning": "day"
-	},
-	{
-		"word": "natu",
-		"meaning": "night"
-	},
-	{
-		"word": "murinu",
-		"meaning": "morning"
-	},
-	{
-		"word": "ebeninku",
-		"meaning": "evening"
-	},
-	{
-		"word": "monadu",
-		"meaning": "month"
-	},
-	{
-		"word": "siconu",
-		"meaning": "season"
-	},
-	{
-		"word": "waru",
-		"meaning": "year"
-	},
-	{
-		"word": "diwaru",
-		"meaning": "decade"
-	},
-	{
-		"word": "huwaru",
-		"meaning": "century"
-	},
-	{
-		"word": "newaru",
-		"meaning": "millenium"
-	},
-	{
-		"word": "nem",
-		"meaning": "mind"
-	},
-	{
-		"word": "pen",
-		"meaning": "movement"
-	},
-	{
-		"word": "nepen",
-		"meaning": "feeling"
-	},
-	{
-		"word": "gurati",
-		"meaning": "negative freedom"
-	},
-	{
-		"word": "lifeta",
-		"meaning": "positive freedom"
-	},
-	{
-		"word": "kumi",
-		"meaning": "trans(gender)ness"
-	},
-	{
-		"word": "jala",
-		"meaning": "ability"
-	},
-	{
-		"word": "mire",
-		"meaning": "half, middle"
-	},
-	{
-		"word": "misu",
-		"meaning": "liquid"
-	},
-	{
-		"word": "lufi",
-		"meaning": "gas"
-	},
-	{
-		"word": "ten",
-		"meaning": "solid"
-	},
-	{
-		"word": "kin",
-		"meaning": "thing"
-	},
-	{
-		"word": "meta",
-		"meaning": "measurment"
-	},
-	{
-		"word": "core",
-		"meaning": "desire"
-	},
-	{
-		"word": "jore",
-		"meaning": "need"
-	},
-	{
-		"word": "lonki",
-		"meaning": "field of knowledge/study"
-	},
-	{
-		"word": "tori",
-		"meaning": "kindness, love"
-	},
-	{
-		"word": "toba",
-		"meaning": "word"
-	},
-	{
-		"word": "bencun",
-		"meaning": "book"
-	},
-	{
-		"word": "gucun",
-		"meaning": "story"
-	},
-	{
-		"word": "bengu",
-		"meaning": "storybook"
-	},
-	{
-		"word": "cikaran",
-		"meaning": "physical strength"
-	},
-	{
-		"word": "cikaranem",
-		"meaning": "mental strength"
-	},
-	{
-		"word": "canwa",
-		"meaning": "result"
-	},
-	{
-		"word": "wucan",
-		"meaning": "victory"
-	},
-	{
-		"word": "dican",
-		"meaning": "defeat"
+		"type": "noun",
+		"entries": [
+			{
+				"word": "kase",
+				"meaning": "cat",
+				"extra": []
+			},
+			{
+				"word": "hun",
+				"meaning": "dog",
+				"extra": []
+			},
+			{
+				"word": "luma",
+				"meaning": "person",
+				"extra": []
+			},
+			{
+				"word": "mawa",
+				"meaning": "kiss",
+				"extra": []
+			},
+			{
+				"word": "lanmi",
+				"meaning": "food",
+				"extra": []
+			},
+			{
+				"word": "topi",
+				"meaning": "god, deity",
+				"extra": []
+			},
+			{
+				"word": "wantu",
+				"meaning": "number",
+				"extra": []
+			},
+			{
+				"word": "cosi",
+				"meaning": "choice, vote",
+				"extra": []
+			},
+			{
+				"word": "falo",
+				"meaning": "speech, discussion, chat",
+				"extra": []
+			},
+			{
+				"word": "linwa",
+				"meaning": "language",
+				"extra": []
+			},
+			{
+				"word": "keso",
+				"meaning": "cheese",
+				"extra": []
+			},
+			{
+				"word": "sekiso",
+				"meaning": "sex, act of fucking",
+				"extra": []
+			},
+			{
+				"word": "lumaba",
+				"meaning": "friend",
+				"extra": []
+			},
+			{
+				"word": "deja",
+				"meaning": "action",
+				"extra": []
+			},
+			{
+				"word": "gade",
+				"meaning": "guess",
+				"extra": []
+			},
+			{
+				"word": "tempu",
+				"meaning": "time",
+				"extra": []
+			},
+			{
+				"word": "cikondu",
+				"meaning": "second",
+				"extra": []
+			},
+			{
+				"word": "minedu",
+				"meaning": "minute",
+				"extra": []
+			},
+			{
+				"word": "haweru",
+				"meaning": "hour",
+				"extra": []
+			},
+			{
+				"word": "dawu",
+				"meaning": "day",
+				"extra": []
+			},
+			{
+				"word": "natu",
+				"meaning": "night",
+				"extra": []
+			},
+			{
+				"word": "murinu",
+				"meaning": "morning",
+				"extra": []
+			},
+			{
+				"word": "ebeninku",
+				"meaning": "evening",
+				"extra": []
+			},
+			{
+				"word": "monadu",
+				"meaning": "month",
+				"extra": []
+			},
+			{
+				"word": "siconu",
+				"meaning": "season",
+				"extra": []
+			},
+			{
+				"word": "waru",
+				"meaning": "year",
+				"extra": []
+			},
+			{
+				"word": "diwaru",
+				"meaning": "decade",
+				"extra": []
+			},
+			{
+				"word": "huwaru",
+				"meaning": "century",
+				"extra": []
+			},
+			{
+				"word": "newaru",
+				"meaning": "millenium",
+				"extra": []
+			},
+			{
+				"word": "nem",
+				"meaning": "mind",
+				"extra": []
+			},
+			{
+				"word": "pen",
+				"meaning": "movement",
+				"extra": []
+			},
+			{
+				"word": "nepen",
+				"meaning": "feeling",
+				"extra": []
+			},
+			{
+				"word": "gurati",
+				"meaning": "negative freedom",
+				"extra": []
+			},
+			{
+				"word": "lifeta",
+				"meaning": "positive freedom",
+				"extra": []
+			},
+			{
+				"word": "kumi",
+				"meaning": "trans(gender)ness",
+				"extra": []
+			},
+			{
+				"word": "jala",
+				"meaning": "ability",
+				"extra": []
+			},
+			{
+				"word": "mire",
+				"meaning": "half, middle",
+				"extra": []
+			},
+			{
+				"word": "misu",
+				"meaning": "liquid",
+				"extra": []
+			},
+			{
+				"word": "lufi",
+				"meaning": "gas",
+				"extra": []
+			},
+			{
+				"word": "ten",
+				"meaning": "solid",
+				"extra": []
+			},
+			{
+				"word": "kin",
+				"meaning": "thing",
+				"extra": []
+			},
+			{
+				"word": "meta",
+				"meaning": "measurment",
+				"extra": []
+			},
+			{
+				"word": "core",
+				"meaning": "desire",
+				"extra": []
+			},
+			{
+				"word": "jore",
+				"meaning": "need",
+				"extra": []
+			},
+			{
+				"word": "lonki",
+				"meaning": "field of knowledge/study",
+				"extra": []
+			},
+			{
+				"word": "tori",
+				"meaning": "kindness, love",
+				"extra": []
+			},
+			{
+				"word": "toba",
+				"meaning": "word",
+				"extra": []
+			},
+			{
+				"word": "bencun",
+				"meaning": "book",
+				"extra": []
+			},
+			{
+				"word": "gucun",
+				"meaning": "story",
+				"extra": []
+			},
+			{
+				"word": "bengu",
+				"meaning": "storybook",
+				"extra": []
+			},
+			{
+				"word": "cikaran",
+				"meaning": "physical strength",
+				"extra": []
+			},
+			{
+				"word": "cikaranem",
+				"meaning": "mental strength",
+				"extra": []
+			},
+			{
+				"word": "canwa",
+				"meaning": "result",
+				"extra": []
+			},
+			{
+				"word": "wucan",
+				"meaning": "victory",
+				"extra": []
+			},
+			{
+				"word": "dican",
+				"meaning": "defeat",
+				"extra": []
+			}
+		]
 	}
 ]

--- a/rawspec/numbers.json
+++ b/rawspec/numbers.json
@@ -1,6 +1,11 @@
 [
 	{
 		"type": "number",
+		"title": null,
+		"headers": [
+			"Word",
+			"Meaning"
+		],
 		"entries": [
 			{
 				"word": "Word",

--- a/rawspec/numbers.json
+++ b/rawspec/numbers.json
@@ -1,410 +1,517 @@
 [
 	{
-		"word": "Word",
-		"meaning": "Number"
-	},
-	{
-		"word": "**sero**",
-		"meaning": "0"
-	},
-	{
-		"word": "**wano**",
-		"meaning": "1"
-	},
-	{
-		"word": "**duwo**",
-		"meaning": "2"
-	},
-	{
-		"word": "**tero**",
-		"meaning": "3"
-	},
-	{
-		"word": "**karo**",
-		"meaning": "4"
-	},
-	{
-		"word": "**bimo**",
-		"meaning": "5"
-	},
-	{
-		"word": "**ciko**",
-		"meaning": "6"
-	},
-	{
-		"word": "**sebo**",
-		"meaning": "7"
-	},
-	{
-		"word": "**wonto**",
-		"meaning": "8"
-	},
-	{
-		"word": "**ninto**",
-		"meaning": "9"
-	},
-	{
-		"word": "**dinko**",
-		"meaning": "10"
-	},
-	{
-		"word": "dunko",
-		"meaning": "20"
-	},
-	{
-		"word": "tenko",
-		"meaning": "30"
-	},
-	{
-		"word": "kanko",
-		"meaning": "40"
-	},
-	{
-		"word": "binko",
-		"meaning": "50"
-	},
-	{
-		"word": "cinko",
-		"meaning": "60"
-	},
-	{
-		"word": "senko",
-		"meaning": "70"
-	},
-	{
-		"word": "wonko",
-		"meaning": "80"
-	},
-	{
-		"word": "ninko",
-		"meaning": "90"
-	},
-	{
-		"word": "**hundo**",
-		"meaning": "100"
-	},
-	{
-		"word": "dundo",
-		"meaning": "200"
-	},
-	{
-		"word": "tendo",
-		"meaning": "300"
-	},
-	{
-		"word": "kando",
-		"meaning": "400"
-	},
-	{
-		"word": "bindo",
-		"meaning": "500"
-	},
-	{
-		"word": "cindo",
-		"meaning": "600"
-	},
-	{
-		"word": "sendo",
-		"meaning": "700"
-	},
-	{
-		"word": "wondo",
-		"meaning": "800"
-	},
-	{
-		"word": "nindo",
-		"meaning": "900"
-	},
-	{
-		"word": "**neko**",
-		"meaning": "1000"
-	},
-	{
-		"word": "duko",
-		"meaning": "2000"
-	},
-	{
-		"word": "teko",
-		"meaning": "3000"
-	},
-	{
-		"word": "keko",
-		"meaning": "4000"
-	},
-	{
-		"word": "biko",
-		"meaning": "5000"
-	},
-	{
-		"word": "ciko",
-		"meaning": "6000"
-	},
-	{
-		"word": "seko",
-		"meaning": "7000"
-	},
-	{
-		"word": "woko",
-		"meaning": "8000"
-	},
-	{
-		"word": "niko",
-		"meaning": "9000"
-	},
-	{
-		"word": "diko",
-		"meaning": "10'000"
-	},
-	{
-		"word": "dudiko",
-		"meaning": "20'000"
-	},
-	{
-		"word": "tediko",
-		"meaning": "30'000"
-	},
-	{
-		"word": "kadiko",
-		"meaning": "40'000"
-	},
-	{
-		"word": "bidiko",
-		"meaning": "50'000"
-	},
-	{
-		"word": "cidiko",
-		"meaning": "60'000"
-	},
-	{
-		"word": "sediko",
-		"meaning": "70'000"
-	},
-	{
-		"word": "wodiko",
-		"meaning": "80'000"
-	},
-	{
-		"word": "nidiko",
-		"meaning": "90'000"
-	},
-	{
-		"word": "huko",
-		"meaning": "100'000"
-	},
-	{
-		"word": "duhuko",
-		"meaning": "200'000"
-	},
-	{
-		"word": "tehuko",
-		"meaning": "300'000"
-	},
-	{
-		"word": "kahuko",
-		"meaning": "400'000"
-	},
-	{
-		"word": "bihuko",
-		"meaning": "500'000"
-	},
-	{
-		"word": "cihuko",
-		"meaning": "600'000"
-	},
-	{
-		"word": "sehuko",
-		"meaning": "700'000"
-	},
-	{
-		"word": "wohuko",
-		"meaning": "800'000"
-	},
-	{
-		"word": "nihuko",
-		"meaning": "900'000"
-	},
-	{
-		"word": "**ranolono**",
-		"meaning": "1'000'000"
-	},
-	{
-		"word": "dunolono",
-		"meaning": "2'000'000"
-	},
-	{
-		"word": "tenolono",
-		"meaning": "3'000'000"
-	},
-	{
-		"word": "kenolono",
-		"meaning": "4'000'000"
-	},
-	{
-		"word": "binolono",
-		"meaning": "5'000'000"
-	},
-	{
-		"word": "cinolono",
-		"meaning": "6'000'000"
-	},
-	{
-		"word": "senolono",
-		"meaning": "7'000'000"
-	},
-	{
-		"word": "wonolono",
-		"meaning": "8'000'000"
-	},
-	{
-		"word": "ninolono",
-		"meaning": "9'000'000"
-	},
-	{
-		"word": "dinolono",
-		"meaning": "10'000'000"
-	},
-	{
-		"word": "dudinolono",
-		"meaning": "20'000'000"
-	},
-	{
-		"word": "tedinolono",
-		"meaning": "30'000'000"
-	},
-	{
-		"word": "kadinolono",
-		"meaning": "40'000'000"
-	},
-	{
-		"word": "bidinolono",
-		"meaning": "50'000'000"
-	},
-	{
-		"word": "cidinolono",
-		"meaning": "60'000'000"
-	},
-	{
-		"word": "sedinolono",
-		"meaning": "70'000'000"
-	},
-	{
-		"word": "wodinolono",
-		"meaning": "80'000'000"
-	},
-	{
-		"word": "nidinolono",
-		"meaning": "90'000'000"
-	},
-	{
-		"word": "hunolono",
-		"meaning": "100'000'000"
-	},
-	{
-		"word": "**rawolono**",
-		"meaning": "1'000'000'000"
-	},
-	{
-		"word": "diwolono",
-		"meaning": "10'000'000'000"
-	},
-	{
-		"word": "huwolono",
-		"meaning": "100'000'000'000"
-	},
-	{
-		"word": "**rerolono**",
-		"meaning": "1'000'000'000'000"
-	},
-	{
-		"word": "dirolono",
-		"meaning": "10'000'000'000'000"
-	},
-	{
-		"word": "hurolono",
-		"meaning": "100'000'000'000'000"
-	},
-	{
-		"word": "**ragolono**",
-		"meaning": "1'000'000'000'000'000"
-	},
-	{
-		"word": "digolono",
-		"meaning": "10'000'000'000'000'000"
-	},
-	{
-		"word": "hugolono",
-		"meaning": "100'000'000'000'000'000"
-	},
-	{
-		"word": "**rimolono**",
-		"meaning": "1'000'000'000'000'000'000"
-	},
-	{
-		"word": "dimolono",
-		"meaning": "10'000'000'000'000'000'000"
-	},
-	{
-		"word": "humolono",
-		"meaning": "100'000'000'000'000'000'000"
-	},
-	{
-		"word": "**rikolono**",
-		"meaning": "1'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "dikolono",
-		"meaning": "10'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "hukolono",
-		"meaning": "100'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "**rebolono**",
-		"meaning": "1'000'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "dibolono",
-		"meaning": "10'000'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "hubolono",
-		"meaning": "100'000'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "**rontolono**",
-		"meaning": "1'000'000'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "dintolono",
-		"meaning": "10'000'000'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "huntolono",
-		"meaning": "100'000'000'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "**rinolono**",
-		"meaning": "1'000'000'000'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "dimpolono",
-		"meaning": "10'000'000'000'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "humpolono",
-		"meaning": "100'000'000'000'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "**rinkolono**",
-		"meaning": "1'000'000'000'000'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "dinkolono",
-		"meaning": "100'000'000'000'000'000'000'000'000'000'000'000"
-	},
-	{
-		"word": "hunkolono",
-		"meaning": "100'000'000'000'000'000'000'000'000'000'000'000"
+		"type": "number",
+		"entries": [
+			{
+				"word": "Word",
+				"meaning": "Number",
+				"extra": []
+			},
+			{
+				"word": "**sero**",
+				"meaning": "0",
+				"extra": []
+			},
+			{
+				"word": "**wano**",
+				"meaning": "1",
+				"extra": []
+			},
+			{
+				"word": "**duwo**",
+				"meaning": "2",
+				"extra": []
+			},
+			{
+				"word": "**tero**",
+				"meaning": "3",
+				"extra": []
+			},
+			{
+				"word": "**karo**",
+				"meaning": "4",
+				"extra": []
+			},
+			{
+				"word": "**bimo**",
+				"meaning": "5",
+				"extra": []
+			},
+			{
+				"word": "**ciko**",
+				"meaning": "6",
+				"extra": []
+			},
+			{
+				"word": "**sebo**",
+				"meaning": "7",
+				"extra": []
+			},
+			{
+				"word": "**wonto**",
+				"meaning": "8",
+				"extra": []
+			},
+			{
+				"word": "**ninto**",
+				"meaning": "9",
+				"extra": []
+			},
+			{
+				"word": "**dinko**",
+				"meaning": "10",
+				"extra": []
+			},
+			{
+				"word": "dunko",
+				"meaning": "20",
+				"extra": []
+			},
+			{
+				"word": "tenko",
+				"meaning": "30",
+				"extra": []
+			},
+			{
+				"word": "kanko",
+				"meaning": "40",
+				"extra": []
+			},
+			{
+				"word": "binko",
+				"meaning": "50",
+				"extra": []
+			},
+			{
+				"word": "cinko",
+				"meaning": "60",
+				"extra": []
+			},
+			{
+				"word": "senko",
+				"meaning": "70",
+				"extra": []
+			},
+			{
+				"word": "wonko",
+				"meaning": "80",
+				"extra": []
+			},
+			{
+				"word": "ninko",
+				"meaning": "90",
+				"extra": []
+			},
+			{
+				"word": "**hundo**",
+				"meaning": "100",
+				"extra": []
+			},
+			{
+				"word": "dundo",
+				"meaning": "200",
+				"extra": []
+			},
+			{
+				"word": "tendo",
+				"meaning": "300",
+				"extra": []
+			},
+			{
+				"word": "kando",
+				"meaning": "400",
+				"extra": []
+			},
+			{
+				"word": "bindo",
+				"meaning": "500",
+				"extra": []
+			},
+			{
+				"word": "cindo",
+				"meaning": "600",
+				"extra": []
+			},
+			{
+				"word": "sendo",
+				"meaning": "700",
+				"extra": []
+			},
+			{
+				"word": "wondo",
+				"meaning": "800",
+				"extra": []
+			},
+			{
+				"word": "nindo",
+				"meaning": "900",
+				"extra": []
+			},
+			{
+				"word": "**neko**",
+				"meaning": "1000",
+				"extra": []
+			},
+			{
+				"word": "duko",
+				"meaning": "2000",
+				"extra": []
+			},
+			{
+				"word": "teko",
+				"meaning": "3000",
+				"extra": []
+			},
+			{
+				"word": "keko",
+				"meaning": "4000",
+				"extra": []
+			},
+			{
+				"word": "biko",
+				"meaning": "5000",
+				"extra": []
+			},
+			{
+				"word": "ciko",
+				"meaning": "6000",
+				"extra": []
+			},
+			{
+				"word": "seko",
+				"meaning": "7000",
+				"extra": []
+			},
+			{
+				"word": "woko",
+				"meaning": "8000",
+				"extra": []
+			},
+			{
+				"word": "niko",
+				"meaning": "9000",
+				"extra": []
+			},
+			{
+				"word": "diko",
+				"meaning": "10'000",
+				"extra": []
+			},
+			{
+				"word": "dudiko",
+				"meaning": "20'000",
+				"extra": []
+			},
+			{
+				"word": "tediko",
+				"meaning": "30'000",
+				"extra": []
+			},
+			{
+				"word": "kadiko",
+				"meaning": "40'000",
+				"extra": []
+			},
+			{
+				"word": "bidiko",
+				"meaning": "50'000",
+				"extra": []
+			},
+			{
+				"word": "cidiko",
+				"meaning": "60'000",
+				"extra": []
+			},
+			{
+				"word": "sediko",
+				"meaning": "70'000",
+				"extra": []
+			},
+			{
+				"word": "wodiko",
+				"meaning": "80'000",
+				"extra": []
+			},
+			{
+				"word": "nidiko",
+				"meaning": "90'000",
+				"extra": []
+			},
+			{
+				"word": "huko",
+				"meaning": "100'000",
+				"extra": []
+			},
+			{
+				"word": "duhuko",
+				"meaning": "200'000",
+				"extra": []
+			},
+			{
+				"word": "tehuko",
+				"meaning": "300'000",
+				"extra": []
+			},
+			{
+				"word": "kahuko",
+				"meaning": "400'000",
+				"extra": []
+			},
+			{
+				"word": "bihuko",
+				"meaning": "500'000",
+				"extra": []
+			},
+			{
+				"word": "cihuko",
+				"meaning": "600'000",
+				"extra": []
+			},
+			{
+				"word": "sehuko",
+				"meaning": "700'000",
+				"extra": []
+			},
+			{
+				"word": "wohuko",
+				"meaning": "800'000",
+				"extra": []
+			},
+			{
+				"word": "nihuko",
+				"meaning": "900'000",
+				"extra": []
+			},
+			{
+				"word": "**ranolono**",
+				"meaning": "1'000'000",
+				"extra": []
+			},
+			{
+				"word": "dunolono",
+				"meaning": "2'000'000",
+				"extra": []
+			},
+			{
+				"word": "tenolono",
+				"meaning": "3'000'000",
+				"extra": []
+			},
+			{
+				"word": "kenolono",
+				"meaning": "4'000'000",
+				"extra": []
+			},
+			{
+				"word": "binolono",
+				"meaning": "5'000'000",
+				"extra": []
+			},
+			{
+				"word": "cinolono",
+				"meaning": "6'000'000",
+				"extra": []
+			},
+			{
+				"word": "senolono",
+				"meaning": "7'000'000",
+				"extra": []
+			},
+			{
+				"word": "wonolono",
+				"meaning": "8'000'000",
+				"extra": []
+			},
+			{
+				"word": "ninolono",
+				"meaning": "9'000'000",
+				"extra": []
+			},
+			{
+				"word": "dinolono",
+				"meaning": "10'000'000",
+				"extra": []
+			},
+			{
+				"word": "dudinolono",
+				"meaning": "20'000'000",
+				"extra": []
+			},
+			{
+				"word": "tedinolono",
+				"meaning": "30'000'000",
+				"extra": []
+			},
+			{
+				"word": "kadinolono",
+				"meaning": "40'000'000",
+				"extra": []
+			},
+			{
+				"word": "bidinolono",
+				"meaning": "50'000'000",
+				"extra": []
+			},
+			{
+				"word": "cidinolono",
+				"meaning": "60'000'000",
+				"extra": []
+			},
+			{
+				"word": "sedinolono",
+				"meaning": "70'000'000",
+				"extra": []
+			},
+			{
+				"word": "wodinolono",
+				"meaning": "80'000'000",
+				"extra": []
+			},
+			{
+				"word": "nidinolono",
+				"meaning": "90'000'000",
+				"extra": []
+			},
+			{
+				"word": "hunolono",
+				"meaning": "100'000'000",
+				"extra": []
+			},
+			{
+				"word": "**rawolono**",
+				"meaning": "1'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "diwolono",
+				"meaning": "10'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "huwolono",
+				"meaning": "100'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "**rerolono**",
+				"meaning": "1'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "dirolono",
+				"meaning": "10'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "hurolono",
+				"meaning": "100'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "**ragolono**",
+				"meaning": "1'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "digolono",
+				"meaning": "10'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "hugolono",
+				"meaning": "100'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "**rimolono**",
+				"meaning": "1'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "dimolono",
+				"meaning": "10'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "humolono",
+				"meaning": "100'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "**rikolono**",
+				"meaning": "1'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "dikolono",
+				"meaning": "10'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "hukolono",
+				"meaning": "100'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "**rebolono**",
+				"meaning": "1'000'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "dibolono",
+				"meaning": "10'000'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "hubolono",
+				"meaning": "100'000'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "**rontolono**",
+				"meaning": "1'000'000'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "dintolono",
+				"meaning": "10'000'000'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "huntolono",
+				"meaning": "100'000'000'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "**rinolono**",
+				"meaning": "1'000'000'000'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "dimpolono",
+				"meaning": "10'000'000'000'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "humpolono",
+				"meaning": "100'000'000'000'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "**rinkolono**",
+				"meaning": "1'000'000'000'000'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "dinkolono",
+				"meaning": "100'000'000'000'000'000'000'000'000'000'000'000",
+				"extra": []
+			},
+			{
+				"word": "hunkolono",
+				"meaning": "100'000'000'000'000'000'000'000'000'000'000'000",
+				"extra": []
+			}
+		]
 	}
 ]

--- a/rawspec/prefixes.json
+++ b/rawspec/prefixes.json
@@ -1,7 +1,17 @@
 [
 	{
 		"type": "prefix",
+		"title": null,
+		"headers": [
+			"Word",
+			"Meaning"
+		],
 		"entries": [
+			{
+				"word": "Spelling",
+				"meaning": "Definition",
+				"extra": []
+			},
 			{
 				"word": "mire-",
 				"meaning": "half, in the middle of",

--- a/rawspec/prefixes.json
+++ b/rawspec/prefixes.json
@@ -1,34 +1,47 @@
 [
 	{
-		"word": "mire-",
-		"meaning": "half, in the middle of"
-	},
-	{
-		"word": "gara-",
-		"meaning": "all/every"
-	},
-	{
-		"word": "coko-",
-		"meaning": "some"
-	},
-	{
-		"word": "boro-",
-		"meaning": "any"
-	},
-	{
-		"word": "ni-",
-		"meaning": "negation, other than"
-	},
-	{
-		"word": "mo-",
-		"meaning": "inversion, contrary meaning"
-	},
-	{
-		"word": "wu-",
-		"meaning": "denotes positive connotation"
-	},
-	{
-		"word": "di-",
-		"meaning": "denotes negative connotation"
+		"type": "prefix",
+		"entries": [
+			{
+				"word": "mire-",
+				"meaning": "half, in the middle of",
+				"extra": []
+			},
+			{
+				"word": "gara-",
+				"meaning": "all/every",
+				"extra": []
+			},
+			{
+				"word": "coko-",
+				"meaning": "some",
+				"extra": []
+			},
+			{
+				"word": "boro-",
+				"meaning": "any",
+				"extra": []
+			},
+			{
+				"word": "ni-",
+				"meaning": "negation, other than",
+				"extra": []
+			},
+			{
+				"word": "mo-",
+				"meaning": "inversion, contrary meaning",
+				"extra": []
+			},
+			{
+				"word": "wu-",
+				"meaning": "denotes positive connotation",
+				"extra": []
+			},
+			{
+				"word": "di-",
+				"meaning": "denotes negative connotation",
+				"extra": []
+			}
+		]
 	}
 ]

--- a/rawspec/prepositions.json
+++ b/rawspec/prepositions.json
@@ -1,50 +1,67 @@
 [
 	{
-		"word": "ra",
-		"meaning": "in"
-	},
-	{
-		"word": "para",
-		"meaning": "for"
-	},
-	{
-		"word": "de",
-		"meaning": "of"
-	},
-	{
-		"word": "no",
-		"meaning": "but"
-	},
-	{
-		"word": "gon",
-		"meaning": "on"
-	},
-	{
-		"word": "huba",
-		"meaning": "over"
-	},
-	{
-		"word": "wuba",
-		"meaning": "under"
-	},
-	{
-		"word": "faba",
-		"meaning": "in front of"
-	},
-	{
-		"word": "caba",
-		"meaning": "behind"
-	},
-	{
-		"word": "tamba",
-		"meaning": "next to"
-	},
-	{
-		"word": "taba",
-		"meaning": "near"
-	},
-	{
-		"word": "kaba",
-		"meaning": "far"
+		"type": "preposition",
+		"entries": [
+			{
+				"word": "ra",
+				"meaning": "in",
+				"extra": []
+			},
+			{
+				"word": "para",
+				"meaning": "for",
+				"extra": []
+			},
+			{
+				"word": "de",
+				"meaning": "of",
+				"extra": []
+			},
+			{
+				"word": "no",
+				"meaning": "but",
+				"extra": []
+			},
+			{
+				"word": "gon",
+				"meaning": "on",
+				"extra": []
+			},
+			{
+				"word": "huba",
+				"meaning": "over",
+				"extra": []
+			},
+			{
+				"word": "wuba",
+				"meaning": "under",
+				"extra": []
+			},
+			{
+				"word": "faba",
+				"meaning": "in front of",
+				"extra": []
+			},
+			{
+				"word": "caba",
+				"meaning": "behind",
+				"extra": []
+			},
+			{
+				"word": "tamba",
+				"meaning": "next to",
+				"extra": []
+			},
+			{
+				"word": "taba",
+				"meaning": "near",
+				"extra": []
+			},
+			{
+				"word": "kaba",
+				"meaning": "far",
+				"extra": []
+			}
+		]
 	}
 ]

--- a/rawspec/prepositions.json
+++ b/rawspec/prepositions.json
@@ -1,7 +1,17 @@
 [
 	{
 		"type": "preposition",
+		"title": null,
+		"headers": [
+			"Word",
+			"Meaning"
+		],
 		"entries": [
+			{
+				"word": "Spelling",
+				"meaning": "Definition",
+				"extra": []
+			},
 			{
 				"word": "ra",
 				"meaning": "in",

--- a/rawspec/pronouns.json
+++ b/rawspec/pronouns.json
@@ -1,58 +1,100 @@
 [
 	{
-		"word": "—",
-		"meaning": "li"
+		"type": "pronoun",
+		"title": "Indefinite Pronouns",
+		"entries": [
+			{
+				"word": "—",
+				"meaning": "li",
+				"extra": [
+					"animate, unspecified, 1st person"
+				]
+			},
+			{
+				"word": "mid",
+				"meaning": "mida",
+				"extra": [
+					"animate, unspecified, 2nd person"
+				]
+			},
+			{
+				"word": "—",
+				"meaning": "da",
+				"extra": [
+					"animate, unspecified, 3rd person"
+				]
+			},
+			{
+				"word": "—",
+				"meaning": "dase",
+				"extra": [
+					"animate, feminine, 3rd person"
+				]
+			},
+			{
+				"word": "—",
+				"meaning": "dake",
+				"extra": [
+					"animate, androfem, 3rd person"
+				]
+			},
+			{
+				"word": "—",
+				"meaning": "daka",
+				"extra": [
+					"animate, androgynous, 3rd person"
+				]
+			},
+			{
+				"word": "—",
+				"meaning": "daki",
+				"extra": [
+					"animate, andromasc, 3rd person"
+				]
+			},
+			{
+				"word": "—",
+				"meaning": "daci",
+				"extra": [
+					"animate, masculine, 3rd person"
+				]
+			}
+		]
 	},
 	{
-		"word": "mid",
-		"meaning": "mida"
-	},
-	{
-		"word": "—",
-		"meaning": "da"
-	},
-	{
-		"word": "—",
-		"meaning": "dase"
-	},
-	{
-		"word": "—",
-		"meaning": "dake"
-	},
-	{
-		"word": "—",
-		"meaning": "daka"
-	},
-	{
-		"word": "—",
-		"meaning": "daki"
-	},
-	{
-		"word": "—",
-		"meaning": "daci"
-	},
-	{
-		"word": "reda",
-		"meaning": "reflexive pronoun, referencing to the thing(s) already mentioned in the sentence"
-	},
-	{
-		"word": "toransu",
-		"meaning": "other"
-	},
-	{
-		"word": "gara",
-		"meaning": "all/every"
-	},
-	{
-		"word": "coko",
-		"meaning": "some"
-	},
-	{
-		"word": "boro",
-		"meaning": "any"
-	},
-	{
-		"word": "mire",
-		"meaning": "half"
+		"type": "pronoun",
+		"title": "Demonstrative Pronouns",
+		"entries": [
+			{
+				"word": "reda",
+				"meaning": "reflexive pronoun, referencing to the thing(s) already mentioned in the sentence",
+				"extra": []
+			},
+			{
+				"word": "toransu",
+				"meaning": "other",
+				"extra": []
+			},
+			{
+				"word": "gara",
+				"meaning": "all/every",
+				"extra": []
+			},
+			{
+				"word": "coko",
+				"meaning": "some",
+				"extra": []
+			},
+			{
+				"word": "boro",
+				"meaning": "any",
+				"extra": []
+			},
+			{
+				"word": "mire",
+				"meaning": "half",
+				"extra": []
+			}
+		]
 	}
 ]

--- a/rawspec/pronouns.json
+++ b/rawspec/pronouns.json
@@ -59,11 +59,16 @@
 					"animate, masculine, 3rd person"
 				]
 			}
+		],
+		"headers": [
+			"Spelling (nonextended — original)",
+			"Spelling",
+			"Definition"
 		]
 	},
 	{
 		"type": "pronoun",
-		"title": "Demonstrative Pronouns",
+		"title": "Demonstrative Pronouns \\_",
 		"entries": [
 			{
 				"word": "reda",
@@ -94,6 +99,127 @@
 				"word": "mire",
 				"meaning": "half",
 				"extra": []
+			}
+		],
+		"headers": [
+			"Spelling",
+			"Definition"
+		]
+	},
+	{
+		"type": "pronoun",
+		"title": "Demonstrative Pronouns (Far From Speaker)",
+		"entries": [
+			{
+				"word": "tano",
+				"meaning": "this",
+				"extra": [
+					"this + n."
+				]
+			},
+			{
+				"word": "tani",
+				"meaning": "this",
+				"extra": [
+					"this + adj."
+				]
+			},
+			{
+				"word": "tatu",
+				"meaning": "this way",
+				"extra": [
+					"as such, in this manner"
+				]
+			},
+			{
+				"word": "talo",
+				"meaning": "such",
+				"extra": [
+					"such, this kind of"
+				]
+			}
+		],
+		"headers": [
+			"Word",
+			"Meaning",
+			"English Equivalent"
+		]
+	},
+	{
+		"type": "pronoun",
+		"title": "Demonstrative Pronouns (Interrogative Form)",
+		"entries": [
+			{
+				"word": "kano",
+				"meaning": "that",
+				"extra": [
+					"that + n."
+				]
+			},
+			{
+				"word": "kani",
+				"meaning": "that",
+				"extra": [
+					"that + adj."
+				]
+			},
+			{
+				"word": "katu",
+				"meaning": "that way",
+				"extra": [
+					"as such, in that manner"
+				]
+			},
+			{
+				"word": "kal",
+				"meaning": "such",
+				"extra": [
+					"such, that kind of"
+				]
+			}
+		],
+		"headers": [
+			"Word",
+			"Meaning",
+			"English Equivalent"
+		]
+	},
+	{
+		"type": "pronoun",
+		"title": "Demonstrative Pronouns (Interrogative Form)",
+		"headers": [
+			"Word",
+			"Meaning",
+			"English Equivalent"
+		],
+		"entries": [
+			{
+				"word": "sono",
+				"meaning": "that",
+				"extra": [
+					"what"
+				]
+			},
+			{
+				"word": "soni",
+				"meaning": "that",
+				"extra": [
+					"which"
+				]
+			},
+			{
+				"word": "sotu",
+				"meaning": "that way",
+				"extra": [
+					"how"
+				]
+			},
+			{
+				"word": "solo",
+				"meaning": "such",
+				"extra": [
+					"what kind of"
+				]
 			}
 		]
 	}

--- a/rawspec/suffixes.json
+++ b/rawspec/suffixes.json
@@ -4,6 +4,13 @@
 		"title": "Verb suffixes",
 		"entries": [
 			{
+				"word": "Spelling",
+				"meaning": "Definition",
+				"extra": [
+					"English equivalents"
+				]
+			},
+			{
 				"word": "-lu",
 				"meaning": "defines an agent noun",
 				"extra": [
@@ -95,6 +102,10 @@
 					"-speak, -talk"
 				]
 			}
+		],
+		"headers": [
+			"Word",
+			"Meaning"
 		]
 	},
 	{
@@ -123,6 +134,13 @@
 				]
 			},
 			{
+				"word": "Spelling",
+				"meaning": "Definition",
+				"extra": [
+					"English equivalents"
+				]
+			},
+			{
 				"word": "-ku",
 				"meaning": "establishes verb as uncertain/questioning",
 				"extra": [
@@ -136,11 +154,21 @@
 					"\"should\", \"ought to\""
 				]
 			}
+		],
+		"headers": [
+			"Spelling",
+			"Definition",
+			"English equivalents"
 		]
 	},
 	{
 		"type": "suffix",
 		"title": "Adjective suffixes",
+		"headers": [
+			"Spelling",
+			"Definition",
+			"English equivalents"
+		],
 		"entries": [
 			{
 				"word": "-jala",

--- a/rawspec/suffixes.json
+++ b/rawspec/suffixes.json
@@ -1,78 +1,154 @@
 [
 	{
-		"word": "-lu",
-		"meaning": "defines an agent noun"
+		"type": "suffix",
+		"title": "Verb suffixes",
+		"entries": [
+			{
+				"word": "-lu",
+				"meaning": "defines an agent noun",
+				"extra": [
+					"-er , -ist"
+				]
+			},
+			{
+				"word": "-sa",
+				"meaning": "indicates plurality",
+				"extra": [
+					"-s, -es"
+				]
+			},
+			{
+				"word": "-ri",
+				"meaning": "establishes a place/event",
+				"extra": [
+					"-ery"
+				]
+			},
+			{
+				"word": "-dufen",
+				"meaning": "refers to an entity or construct that performs a specific action or function",
+				"extra": [
+					"-ifier, -inator"
+				]
+			},
+			{
+				"word": "-fe",
+				"meaning": "connotes opposition",
+				"extra": [
+					"\"against\" , \"in opposition to\"",
+					"—"
+				]
+			},
+			{
+				"word": "-se",
+				"meaning": "establishes feminine characteristics/gender",
+				"extra": [
+					"—"
+				]
+			},
+			{
+				"word": "-ke",
+				"meaning": "establishes androfeminine characteristics/gender",
+				"extra": [
+					"—"
+				]
+			},
+			{
+				"word": "-ka",
+				"meaning": "establishes androgynous characteristics/gender",
+				"extra": [
+					"—"
+				]
+			},
+			{
+				"word": "-ki",
+				"meaning": "establishes andromasc characteristics/gender",
+				"extra": [
+					"—"
+				]
+			},
+			{
+				"word": "-ci",
+				"meaning": "establishes masculine characteristics/gender",
+				"extra": [
+					"—"
+				]
+			},
+			{
+				"word": "-pa",
+				"meaning": "marks word as possessive",
+				"extra": [
+					"-'s"
+				]
+			},
+			{
+				"word": "-lonki",
+				"meaning": "refers to a field of knowledge/study",
+				"extra": [
+					"-ology, -graphy, -nomy, -ics"
+				]
+			},
+			{
+				"word": "-falo",
+				"meaning": "indicates manner or characteristic of speech ",
+				"extra": [
+					"-speak, -talk"
+				]
+			}
+		]
 	},
 	{
-		"word": "-sa",
-		"meaning": "indicates plurality"
+		"type": "suffix",
+		"title": "Adjective suffixes",
+		"entries": [
+			{
+				"word": "-da",
+				"meaning": "refers to the past tense form of a verb",
+				"extra": [
+					"-ed"
+				]
+			},
+			{
+				"word": "-ne",
+				"meaning": "refers to the present tense form of a verb",
+				"extra": [
+					"-ing"
+				]
+			},
+			{
+				"word": "-lo",
+				"meaning": "refers to the future tense form of a verb",
+				"extra": [
+					"\"will\", \"shall\""
+				]
+			},
+			{
+				"word": "-ku",
+				"meaning": "establishes verb as uncertain/questioning",
+				"extra": [
+					"—"
+				]
+			},
+			{
+				"word": "-do",
+				"meaning": "establishes verb as imperative",
+				"extra": [
+					"\"should\", \"ought to\""
+				]
+			}
+		]
 	},
 	{
-		"word": "-ri",
-		"meaning": "establishes a place/event"
-	},
-	{
-		"word": "-dufen",
-		"meaning": "refers to an entity or construct that performs a specific action or function"
-	},
-	{
-		"word": "-fe",
-		"meaning": "connotes opposition"
-	},
-	{
-		"word": "-se",
-		"meaning": "establishes feminine characteristics/gender"
-	},
-	{
-		"word": "-ke",
-		"meaning": "establishes androfeminine characteristics/gender"
-	},
-	{
-		"word": "-ka",
-		"meaning": "establishes androgynous characteristics/gender"
-	},
-	{
-		"word": "-ki",
-		"meaning": "establishes andromasc characteristics/gender"
-	},
-	{
-		"word": "-ci",
-		"meaning": "establishes masculine characteristics/gender"
-	},
-	{
-		"word": "-pa",
-		"meaning": "marks word as possessive"
-	},
-	{
-		"word": "-lonki",
-		"meaning": "refers to a field of knowledge/study"
-	},
-	{
-		"word": "-falo",
-		"meaning": "indicates manner or characteristic of speech "
-	},
-	{
-		"word": "-da",
-		"meaning": "refers to the past tense form of a verb"
-	},
-	{
-		"word": "-ne",
-		"meaning": "refers to the present tense form of a verb"
-	},
-	{
-		"word": "-lo",
-		"meaning": "refers to the future tense form of a verb"
-	},
-	{
-		"word": "-ku",
-		"meaning": "establishes verb as uncertain/questioning"
-	},
-	{
-		"word": "-do",
-		"meaning": "establishes verb as imperative"
-	},
-	{
-		"word": "-jala",
-		"meaning": "denotes ability or capacity"
+		"type": "suffix",
+		"title": "Adjective suffixes",
+		"entries": [
+			{
+				"word": "-jala",
+				"meaning": "denotes ability or capacity",
+				"extra": [
+					"-able , -ible , \"capable of\""
+				]
+			}
+		]
 	}
 ]

--- a/rawspec/verbs.json
+++ b/rawspec/verbs.json
@@ -1,7 +1,17 @@
 [
 	{
 		"type": "verb",
+		"title": null,
+		"headers": [
+			"Word",
+			"Meaning"
+		],
 		"entries": [
+			{
+				"word": "Spelling",
+				"meaning": "Definition",
+				"extra": []
+			},
 			{
 				"word": "mawa",
 				"meaning": "kiss",

--- a/rawspec/verbs.json
+++ b/rawspec/verbs.json
@@ -1,102 +1,132 @@
 [
 	{
-		"word": "mawa",
-		"meaning": "kiss"
-	},
-	{
-		"word": "binta",
-		"meaning": "eat"
-	},
-	{
-		"word": "sanu",
-		"meaning": "be"
-	},
-	{
-		"word": "tenco",
-		"meaning": "have"
-	},
-	{
-		"word": "somo",
-		"meaning": "sleep"
-	},
-	{
-		"word": "cosi",
-		"meaning": "choose, vote"
-	},
-	{
-		"word": "falo",
-		"meaning": "speak, say, tell"
-	},
-	{
-		"word": "toransu",
-		"meaning": "differ"
-	},
-	{
-		"word": "mahen",
-		"meaning": "make, create"
-	},
-	{
-		"word": "sekiso",
-		"meaning": "have sex, fuck"
-	},
-	{
-		"word": "deja",
-		"meaning": "do, act"
-	},
-	{
-		"word": "gade",
-		"meaning": "guess"
-	},
-	{
-		"word": "nem",
-		"meaning": "think"
-	},
-	{
-		"word": "pen",
-		"meaning": "move"
-	},
-	{
-		"word": "nepen",
-		"meaning": "feel"
-	},
-	{
-		"word": "gurati",
-		"meaning": "induce negative freedom, reduce cost to none"
-	},
-	{
-		"word": "lifeta",
-		"meaning": "induce positive freedom"
-	},
-	{
-		"word": "jala",
-		"meaning": "can, be able to"
-	},
-	{
-		"word": "meta",
-		"meaning": "measure"
-	},
-	{
-		"word": "core",
-		"meaning": "want"
-	},
-	{
-		"word": "jore",
-		"meaning": "need"
-	},
-	{
-		"word": "pora",
-		"meaning": "to add, to increase"
-	},
-	{
-		"word": "mina",
-		"meaning": "to subtract, to decrease, to remove"
-	},
-	{
-		"word": "mulipa",
-		"meaning": "to multiply"
-	},
-	{
-		"word": "cipan",
-		"meaning": "to divide, to split"
+		"type": "verb",
+		"entries": [
+			{
+				"word": "mawa",
+				"meaning": "kiss",
+				"extra": []
+			},
+			{
+				"word": "binta",
+				"meaning": "eat",
+				"extra": []
+			},
+			{
+				"word": "sanu",
+				"meaning": "be",
+				"extra": []
+			},
+			{
+				"word": "tenco",
+				"meaning": "have",
+				"extra": []
+			},
+			{
+				"word": "somo",
+				"meaning": "sleep",
+				"extra": []
+			},
+			{
+				"word": "cosi",
+				"meaning": "choose, vote",
+				"extra": []
+			},
+			{
+				"word": "falo",
+				"meaning": "speak, say, tell",
+				"extra": []
+			},
+			{
+				"word": "toransu",
+				"meaning": "differ",
+				"extra": []
+			},
+			{
+				"word": "mahen",
+				"meaning": "make, create",
+				"extra": []
+			},
+			{
+				"word": "sekiso",
+				"meaning": "have sex, fuck",
+				"extra": []
+			},
+			{
+				"word": "deja",
+				"meaning": "do, act",
+				"extra": []
+			},
+			{
+				"word": "gade",
+				"meaning": "guess",
+				"extra": []
+			},
+			{
+				"word": "nem",
+				"meaning": "think",
+				"extra": []
+			},
+			{
+				"word": "pen",
+				"meaning": "move",
+				"extra": []
+			},
+			{
+				"word": "nepen",
+				"meaning": "feel",
+				"extra": []
+			},
+			{
+				"word": "gurati",
+				"meaning": "induce negative freedom, reduce cost to none",
+				"extra": []
+			},
+			{
+				"word": "lifeta",
+				"meaning": "induce positive freedom",
+				"extra": []
+			},
+			{
+				"word": "jala",
+				"meaning": "can, be able to",
+				"extra": []
+			},
+			{
+				"word": "meta",
+				"meaning": "measure",
+				"extra": []
+			},
+			{
+				"word": "core",
+				"meaning": "want",
+				"extra": []
+			},
+			{
+				"word": "jore",
+				"meaning": "need",
+				"extra": []
+			},
+			{
+				"word": "pora",
+				"meaning": "to add, to increase",
+				"extra": []
+			},
+			{
+				"word": "mina",
+				"meaning": "to subtract, to decrease, to remove",
+				"extra": []
+			},
+			{
+				"word": "mulipa",
+				"meaning": "to multiply",
+				"extra": []
+			},
+			{
+				"word": "cipan",
+				"meaning": "to divide, to split",
+				"extra": []
+			}
+		]
 	}
 ]

--- a/scripting/index.ts
+++ b/scripting/index.ts
@@ -25,7 +25,8 @@ for (const file of Files) {
 		.map(v => v.trim())
 		.filter(
 			v =>
-				!v.includes('Spelling | Definition') && !v.includes('Word | Meaning') &&
+				!v.includes('Spelling | Definition') &&
+				!v.includes('Word | Meaning') &&
 				v.replaceAll(/[\|\s\-]/g, '').length > 0 &&
 				(/^\| [^|]+ \|( [^|]+ \|)+$/.test(v) || /^## [a-zA-Z\s]+$/.test(v))
 		);

--- a/scripting/index.ts
+++ b/scripting/index.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { Entry, FullEntry, WordType } from './types';
+import { Entry, FullEntry, Section, WordType } from './types';
 
 const SourceDirectory = join(
 	dirname(fileURLToPath(import.meta.url)),
@@ -25,36 +25,64 @@ for (const file of Files) {
 		.map(v => v.trim())
 		.filter(
 			v =>
-				!v.includes('Spelling | Definition') && !v.includes('Word | Meaning') &&
+				!v.includes('Spelling | Definition') &&
+				!v.includes('Word | Meaning') &&
 				v.replaceAll(/[\|\s\-]/g, '').length > 0 &&
-				/^\| [^|]+ \|( [^|]+ \|)+$/.test(v)
+				(/^\| [^|]+ \|( [^|]+ \|)+$/.test(v) || /^## [a-zA-Z\s]+$/.test(v))
 		);
-	// console.log(file, rows);
-	const map = rows.map(row =>
-		row
-			.slice(1, -1)
-			.split('|')
-			.map(v => v.slice(1, -1))
-	);
-	// console.log(file, map);
-	const data: Entry[] = map.map(([word, meaning]) => ({ word, meaning }));
 
-	const wordType = (() => {
+	const type = (() => {
 		const asdf = file.toLowerCase().replace(/s\.md$/, '');
 		if (asdf === 'prefixe') return 'prefix';
 		if (asdf === 'suffixe') return 'suffix';
 		else return asdf;
 	})() as WordType;
 
+	const sectionStack: Section[] = [];
+	let subSectionStack: Entry[] = [];
+	let title = undefined;
+	for (const row of rows) {
+		if (/^## [a-zA-Z\s]+$/.test(row)) {
+			title = row.slice(3);
+			subSectionStack.length > 0 &&
+				sectionStack.push({ type, title, entries: subSectionStack });
+			subSectionStack = [];
+		} else {
+			const [word, meaning, ...extra] = row
+				.slice(1, -1)
+				.split('|')
+				.map(v => v.slice(1, -1));
+			subSectionStack.push({ word, meaning, extra });
+			CompleteDictionaryStack.push({
+				word,
+				meaning,
+				extra,
+				type
+			} satisfies FullEntry);
+		}
+	}
+	subSectionStack.length > 0 &&
+		sectionStack.push({ type, title, entries: subSectionStack });
+
+	const map = rows.map(row =>
+		row
+			.slice(1, -1)
+			.split('|')
+			.map(v => v.slice(1, -1))
+	);
+
 	const targetFile = join(
 		TargetDirectory,
 		file.toLowerCase().replace(/\.md$/, '.json')
 	);
 
-	await writeFile(targetFile, JSON.stringify(data, null, '	'), 'utf-8');
+	await writeFile(targetFile, JSON.stringify(sectionStack, null, '	'), 'utf-8');
 
 	CompleteDictionaryStack.push(
-		...data.map(entry => ({ ...entry, type: wordType }) satisfies FullEntry)
+		...map.map(
+			([word, meaning, ...extra]) =>
+				({ word, meaning, extra, type }) satisfies FullEntry
+		)
 	);
 }
 

--- a/scripting/index.ts
+++ b/scripting/index.ts
@@ -22,9 +22,10 @@ for (const file of Files) {
 	const content = await readFile(join(SourceDirectory, file), 'utf-8');
 	const rows = content
 		.split('\n')
+		.map(v => v.trim())
 		.filter(
 			v =>
-				!v.includes('Spelling') &&
+				!v.includes('Spelling | Definition') && !v.includes('Word | Meaning') &&
 				v.replaceAll(/[\|\s\-]/g, '').length > 0 &&
 				/^\| [^|]+ \|( [^|]+ \|)+$/.test(v)
 		);

--- a/scripting/types.ts
+++ b/scripting/types.ts
@@ -1,6 +1,7 @@
 export interface Section {
-	title?: string;
+	title: string | null;
 	type: WordType;
+	headers: string[];
 	entries: Entry[];
 }
 

--- a/scripting/types.ts
+++ b/scripting/types.ts
@@ -1,9 +1,16 @@
+export interface Section {
+	title?: string;
+	type: WordType;
+	entries: Entry[];
+}
+
 /**
  * The type of the entry in each separated file (i.e. verbs.json)
  */
 export interface Entry {
 	word: string;
 	meaning: string;
+	extra?: string[];
 }
 
 /**


### PR DESCRIPTION
- adds sectioning (i.e. the pronouns spec will have different sections for personal, indefinite, etc.)
- adds headers for each table (reads the header row for each subsection)
- **Copied a HTML table into multiple vanila Markdown tables in `Pronouns.md`**