### PR TITLE
ensure markdown compatibility with parser

### DIFF
--- a/Vocabulary/Suffixes.md
+++ b/Vocabulary/Suffixes.md
@@ -1,6 +1,6 @@
 # Suffixes
 
-### (Pro)noun suffixes
+## (Pro)noun suffixes
 
 | Spelling | Definition | English equivalents |
 |----------|------------|---------------------|
@@ -18,16 +18,14 @@
 | -lonki | refers to a field of knowledge/study | -ology, -graphy, -nomy, -ics |
 | -falo | indicates manner or characteristic of speech  | -speak, -talk |
 
-## Verb suffixes
-
-### Temporal suffixes
+## Temporal verb suffixes
 | Spelling | Definition | English equivalents |
 |----------|------------|---------------------|
 | -da | refers to the past tense form of a verb | -ed |
 | -ne | refers to the present tense form of a verb | -ing |
 | -lo | refers to the future tense form of a verb | "will", "shall" |
 
-### Other verb suffixes
+## Other verb suffixes
 
 | Spelling | Definition | English equivalents |
 |----------|------------|---------------------|

--- a/scripting/index.ts
+++ b/scripting/index.ts
@@ -16,7 +16,6 @@ const TargetDirectory = join(
 );
 
 const Files = await readdir(SourceDirectory);
-
 const CompleteDictionaryStack: FullEntry[] = [];
 
 const h2Matcher = /^## [A-z\s!-,]+$/;
@@ -60,7 +59,6 @@ for (const file of Files) {
 			if (justStartedNewSection) {
 				headers = [word, meaning, ...extra];
 				justStartedNewSection = false;
-				console.log({ headers, file });
 			} else {
 				subSectionStack.push({ word, meaning, extra });
 				CompleteDictionaryStack.push({
@@ -75,26 +73,12 @@ for (const file of Files) {
 	subSectionStack.length > 0 &&
 		sectionStack.push({ type, title, headers, entries: subSectionStack });
 
-	const map = rows.map(row =>
-		row
-			.slice(1, -1)
-			.split('|')
-			.map(v => v.slice(1, -1))
-	);
-
 	const targetFile = join(
 		TargetDirectory,
 		file.toLowerCase().replace(/\.md$/, '.json')
 	);
 
 	await writeFile(targetFile, JSON.stringify(sectionStack, null, '	'), 'utf-8');
-
-	CompleteDictionaryStack.push(
-		...map.map(
-			([word, meaning, ...extra]) =>
-				({ word, meaning, extra, type }) satisfies FullEntry
-		)
-	);
 }
 
 await writeFile(


### PR DESCRIPTION
Problem: Markdown file format is nonstandard; parser can't pick up everything or picks up stuff it shouldn't (latter issue fixed)

Solution: Searched for inconsistencies, fixed them. In the future, maybe add a format guide to ensure consistency?

Current format:

```md
# Heading (i.e. Adverbs)

## Subheading (optional)

| Col1 | Col2 | etc |
| ---- | ---- | --- |
| asdf | ghjk | 123 | 
```

Future proposal: Update `Formatting.md` to reflect this requirement?